### PR TITLE
Fix build for aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ serde = { version = "1.0.148", features = ["derive"] }
 serde-big-array = "0.5.1"
 bincode = "1.3.3"
 
+[features]
+default = ["prefetch"]
+prefetch = []
+
 [profile.release]
 lto = true
 debug = true

--- a/src/darray/mod.rs
+++ b/src/darray/mod.rs
@@ -66,6 +66,7 @@ use crate::BitVector;
 use crate::{AccessBin, SelectBin, SpaceUsage};
 
 use serde::{Deserialize, Serialize};
+#[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::_popcnt64;
 
 const BLOCK_SIZE: usize = 1024;
@@ -396,9 +397,15 @@ impl<const SELECT0_SUPPORT: bool> DArray<SELECT0_SUPPORT> {
 
         loop {
             let popcnt;
-            //popcnt = word.count_ones() as usize;
-            unsafe {
-                popcnt = _popcnt64(word as i64) as usize;
+            #[cfg(not(target_arch = "x86_64"))]
+            {
+                popcnt = word.count_ones() as usize;
+            }
+            #[cfg(target_arch = "x86_64")]
+            {
+                unsafe {
+                    popcnt = _popcnt64(word as i64) as usize;
+                }
             }
             if reminder < popcnt {
                 break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(
+    all(feature = "prefetch", target_arch = "aarch64"),
+    feature(stdarch_aarch64_prefetch)
+)]
 
 pub mod perf_and_test_utils;
 pub mod qvector;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,9 +6,9 @@ use std::ops::Shr;
 
 #[allow(non_snake_case)]
 pub fn prefetch_read_NTA<T>(data: &[T], offset: usize) {
-    let p = unsafe { data.as_ptr().add(offset) as *const i8 };
+    let _p = unsafe { data.as_ptr().add(offset) as *const i8 };
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(all(feature = "prefetch", any(target_arch = "x86", target_arch = "x86_64")))]
     {
         #[cfg(target_arch = "x86")]
         use std::arch::x86::{_mm_prefetch, _MM_HINT_NTA};
@@ -17,17 +17,16 @@ pub fn prefetch_read_NTA<T>(data: &[T], offset: usize) {
         use std::arch::x86_64::{_mm_prefetch, _MM_HINT_NTA};
 
         unsafe {
-            _mm_prefetch(p, _MM_HINT_NTA);
+            _mm_prefetch(_p, _MM_HINT_NTA);
         }
     }
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(feature = "prefetch", target_arch = "aarch64"))]
     {
-        #[cfg(target_arch = "aarch64")]
         use core::arch::aarch64::{_prefetch, _PREFETCH_LOCALITY0, _PREFETCH_READ};
 
         unsafe {
-            _prefetch(p, _PREFETCH_READ, _PREFETCH_LOCALITY0);
+            _prefetch(_p, _PREFETCH_READ, _PREFETCH_LOCALITY0);
         }
     }
 }


### PR DESCRIPTION
Hey @rossanoventurini - I've made a few changes on top of develop so I could built and test the library on my aarch64 machine. Thanks for fixing the test failures too - that one had me confused till I noticed you had an in progress branch too!

----

Changes to Rust Nightly handling of SIMD features also means a new `stdarch_aarch64_prefetch` feature for `aarch64::_prefetch` use.

Add a crate-level feature that can be disabled for stable builds or comparative benchmarking.

Also make use of `_popcnt64` conditional on x86_64.