### PR TITLE
support 32 bit targets

### DIFF
--- a/src/bitvector/rs_narrow.rs
+++ b/src/bitvector/rs_narrow.rs
@@ -122,18 +122,18 @@ impl RSNarrow {
     }
 
     #[inline(always)]
-    fn sub_block_ranks(&self, block: usize) -> usize {
-        self.block_rank_pairs[block * 2 + 1] as usize
+    fn sub_block_ranks(&self, block: usize) -> u64 {
+        self.block_rank_pairs[block * 2 + 1]
     }
 
     #[inline(always)]
     fn sub_block_rank(&self, sub_block: usize) -> usize {
-        let mut result = 0;
+        let mut result = 0u64;
         let block = sub_block / BLOCK_SIZE;
-        result += self.block_rank(block);
+        result += self.block_rank(block) as u64;
         let left = sub_block % BLOCK_SIZE;
         result += self.sub_block_ranks(block) >> ((7 - left) * 9) & 0x1FF;
-        result
+        result as usize
     }
 
     #[inline(always)]

--- a/src/qvector/rs_qvector/rs_support_plain.rs
+++ b/src/qvector/rs_qvector/rs_support_plain.rs
@@ -34,7 +34,7 @@ impl<const B_SIZE: usize> RSSupport for RSSupportPlain<B_SIZE> {
     const BLOCK_SIZE: usize = B_SIZE;
 
     fn new(qv: &QVector) -> Self {
-        assert!(qv.len() < (1 << 43));
+        assert!(qv.len() < (1 << std::cmp::min(43, usize::BITS - 4))); // TODO: refine upper limit for 32 bit
 
         assert!(
             (Self::BLOCK_SIZE == 256) | (Self::BLOCK_SIZE == 512),


### PR DESCRIPTION
While 32 bit targets were not explicitly excluded, 64 is assumed at two places where shifts go out of bounds of 32 bit.
Please check and refine the best value for the maximum length in src/qvector/rs_qvector/rs_support_plain.rs.
Resolves <https://github.com/rossanoventurini/qwt/issues/11>.