### PR TITLE
Switch mem_dbg dependency source for GitHub to crates.io release 0.3.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0.148", features = ["derive"] }
 serde-big-array = "0.5.1"
 bincode = "1.3.3"
 minimum_redundancy = "0.3.1"
-mem_dbg = { git = "https://github.com/zommiommy/mem_dbg-rs.git", branch = "main" }
+mem_dbg = "0.3.4"
 
 [features]
 default = ["prefetch"]


### PR DESCRIPTION
They just released version 0.3.4, I assume the GitHub dependency is not needed anymore?
I ran `cargo build --release` and then all the binaries `ls target/release/perf_* | grep -v "\.d" | xargs sh -c ` successfully.