### PR TITLE
Add BitVector constructor from already-packed data

### DIFF
--- a/src/bitvector/mod.rs
+++ b/src/bitvector/mod.rs
@@ -290,12 +290,12 @@ impl BitVector {
     /// use qwt::BitVector;
     ///
     /// let v = [0b1110];
-    /// let bv = BitVector::new(&v,4);
+    /// let bv = BitVector::from_packed_data(&v,4);
     /// assert_eq!(bv.words()[0], 0b1110);
     /// ```
     #[must_use]
     #[inline]
-    pub fn new(data: &[u64], n_bits: usize) -> Self {
+    pub fn from_packed_data(data: &[u64], n_bits: usize) -> Self {
         let mut v = BitVectorMut::new();
         if let [rest @ .., last] = data {
             for d in rest {

--- a/src/bitvector/mod.rs
+++ b/src/bitvector/mod.rs
@@ -872,6 +872,10 @@ impl BitVectorMut {
 
     /// Construct a BitVector directly from already-packed data.
     ///
+    /// # Panics
+    ///
+    /// Panics if the length l of the data is 0 or n_bits is outside ((l-1)*64, l*64].
+    ///
     /// # Examples
     ///
     /// ```
@@ -884,6 +888,7 @@ impl BitVectorMut {
     #[must_use]
     #[inline]
     pub fn from_packed_data(data: &[u64], n_bits: usize) -> Self {
+        assert!(data.len() > 0 && n_bits > (data.len() - 1) * 64 && n_bits <= data.len() * 64);
         let mut v = BitVectorMut::with_capacity(n_bits);
         if let [rest @ .., last] = data {
             for d in rest {

--- a/src/bitvector/mod.rs
+++ b/src/bitvector/mod.rs
@@ -884,7 +884,7 @@ impl BitVectorMut {
     #[must_use]
     #[inline]
     pub fn from_packed_data(data: &[u64], n_bits: usize) -> Self {
-        let mut v = BitVectorMut::new();
+        let mut v = BitVectorMut::with_capacity(n_bits);
         if let [rest @ .., last] = data {
             for d in rest {
                 v.append_bits(*d, 64);

--- a/src/bitvector/mod.rs
+++ b/src/bitvector/mod.rs
@@ -282,6 +282,30 @@ impl BitVector {
         &cast_to_u64_slice(&self.data)[..self.n_bits.div_ceil(64)]
     }
 
+    /// Construct a BitVector directly from already-packed data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use qwt::BitVector;
+    ///
+    /// let v = [0b1110];
+    /// let bv = BitVector::new(&v,4);
+    /// assert_eq!(bv.words()[0], 0b1110);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn new(data: &[u64], n_bits: usize) -> Self {
+        let mut v = BitVectorMut::new();
+        if let [rest @ .., last] = data {
+            for d in rest {
+                v.append_bits(*d, 64);
+            }
+            v.append_bits(*last, n_bits % 64);
+        }
+        v.into()
+    }
+
     /// Returns a non-consuming iterator over positions of bits set to 1 in the bit vector.
     ///
     /// # Examples

--- a/src/bitvector/mod.rs
+++ b/src/bitvector/mod.rs
@@ -282,30 +282,6 @@ impl BitVector {
         &cast_to_u64_slice(&self.data)[..self.n_bits.div_ceil(64)]
     }
 
-    /// Construct a BitVector directly from already-packed data.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use qwt::BitVector;
-    ///
-    /// let v = [0b1110];
-    /// let bv = BitVector::from_packed_data(&v,4);
-    /// assert_eq!(bv.words()[0], 0b1110);
-    /// ```
-    #[must_use]
-    #[inline]
-    pub fn from_packed_data(data: &[u64], n_bits: usize) -> Self {
-        let mut v = BitVectorMut::new();
-        if let [rest @ .., last] = data {
-            for d in rest {
-                v.append_bits(*d, 64);
-            }
-            v.append_bits(*last, n_bits % 64);
-        }
-        v.into()
-    }
-
     /// Returns a non-consuming iterator over positions of bits set to 1 in the bit vector.
     ///
     /// # Examples
@@ -892,6 +868,30 @@ impl BitVectorMut {
         bv.extend_with_zeros(n_bits);
         bv.shrink_to_fit();
         bv
+    }
+
+    /// Construct a BitVector directly from already-packed data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use qwt::{BitVectorMut, BitVector};
+    ///
+    /// let v = [0b1110];
+    /// let bv: BitVector = BitVectorMut::from_packed_data(&v,4).into();
+    /// assert_eq!(bv.words()[0], 0b1110);
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn from_packed_data(data: &[u64], n_bits: usize) -> Self {
+        let mut v = BitVectorMut::new();
+        if let [rest @ .., last] = data {
+            for d in rest {
+                v.append_bits(*d, 64);
+            }
+            v.append_bits(*last, n_bits % 64);
+        }
+        v
     }
 
     /// Pushes a `bit` at the end of the bit vector.

--- a/src/bitvector/mod.rs
+++ b/src/bitvector/mod.rs
@@ -870,11 +870,11 @@ impl BitVectorMut {
         bv
     }
 
-    /// Construct a BitVector directly from already-packed data.
+    /// Construct a BitVector directly from the first n_bits of already-packed data.
     ///
     /// # Panics
     ///
-    /// Panics if the length l of the data is 0 or n_bits is outside ((l-1)*64, l*64].
+    /// Panics if n_bits is larger than data.len() * 64.
     ///
     /// # Examples
     ///
@@ -888,13 +888,14 @@ impl BitVectorMut {
     #[must_use]
     #[inline]
     pub fn from_packed_data(data: &[u64], n_bits: usize) -> Self {
-        assert!(data.len() > 0 && n_bits > (data.len() - 1) * 64 && n_bits <= data.len() * 64);
+        assert!(n_bits <= data.len() * 64);
+        let data = &data[..n_bits.div_ceil(64)];
         let mut v = BitVectorMut::with_capacity(n_bits);
         if let [rest @ .., last] = data {
             for d in rest {
                 v.append_bits(*d, 64);
             }
-            v.append_bits(*last, n_bits % 64);
+            v.append_bits(*last, ((n_bits - 1) % 64) + 1);
         }
         v
     }

--- a/src/bitvector/tests.rs
+++ b/src/bitvector/tests.rs
@@ -18,6 +18,14 @@ fn build_alternate(n: usize) -> BitVectorMut {
 }
 
 #[test]
+fn test_new() {
+    let n = 1024 + 13;
+    let v1: BitVector = build_alternate(n).into();
+    let v2 = BitVector::new(v1.words(), v1.len());
+    assert_eq!(v1, v2);
+}
+
+#[test]
 fn test_get() {
     let n = 1024 + 13;
     let bv = build_alternate(n);

--- a/src/bitvector/tests.rs
+++ b/src/bitvector/tests.rs
@@ -18,10 +18,10 @@ fn build_alternate(n: usize) -> BitVectorMut {
 }
 
 #[test]
-fn test_new() {
+fn test_from_packed_data() {
     let n = 1024 + 13;
     let v1: BitVector = build_alternate(n).into();
-    let v2 = BitVector::new(v1.words(), v1.len());
+    let v2 = BitVector::from_packed_data(v1.words(), v1.len());
     assert_eq!(v1, v2);
 }
 

--- a/src/bitvector/tests.rs
+++ b/src/bitvector/tests.rs
@@ -21,8 +21,8 @@ fn build_alternate(n: usize) -> BitVectorMut {
 fn test_from_packed_data() {
     let n = 1024 + 13;
     let v1: BitVector = build_alternate(n).into();
-    let v2 = BitVector::from_packed_data(v1.words(), v1.len());
-    assert_eq!(v1, v2);
+    let v2 = BitVectorMut::from_packed_data(v1.words(), v1.len());
+    assert_eq!(v1, v2.into());
 }
 
 #[test]

--- a/src/bitvector/tests.rs
+++ b/src/bitvector/tests.rs
@@ -19,10 +19,14 @@ fn build_alternate(n: usize) -> BitVectorMut {
 
 #[test]
 fn test_from_packed_data() {
-    let n = 1024 + 13;
+    let n = 1024;
     let v1: BitVector = build_alternate(n).into();
     let v2 = BitVectorMut::from_packed_data(v1.words(), v1.len());
     assert_eq!(v1, v2.into());
+    let partial = BitVectorMut::from_packed_data(v1.words(), 64);
+    assert_eq!(partial, build_alternate(64));
+    let empty = BitVectorMut::from_packed_data(&[], 0);
+    assert_eq!(empty, BitVectorMut::new());
 }
 
 #[test]


### PR DESCRIPTION
To get issue #9 by @RagnarGrootKoerkamp closer to a solution (I would immediately use that in my own code as well), I am proposing a naive implementation here, which just calls append_bits in a loop.
Feel free to modify this as much as you want, I just want establish a baseline here.
There is probably a much faster optimized way to achieve this using unsafe code and by casting a given array that has a length divisible by 8 into the data line, like a reverse cast_to_u64_slice, but I think if true then @rossanoventurini probably has way better insights of how to best achieve this.
Also the number of one-bits then would need to be counted as well.
There could also be a discussion on whether this makes more sense inside BitVector as proposed here or inside BitVectorMut, but at least in my personal use cases when loading a pre-packed BitVector from a file then I don't plan on modifying it, but your use cases may of course be different.