### PR TITLE
Refactor function names n_ones to count_ones and n_zeros to count_zeros

### DIFF
--- a/src/bin/perf_rs_narrow.rs
+++ b/src/bin/perf_rs_narrow.rs
@@ -111,18 +111,18 @@ fn main() {
         let rs = RSNarrow::new(bv);
 
         println!(
-            "created new rs_narrow | n_ones: {} | n_zeros: {}",
-            rs.n_ones(),
-            rs.n_zeros(),
+            "created new rs_narrow | count_ones: {} | count_zeros: {}",
+            rs.count_ones(),
+            rs.count_zeros(),
         );
 
         let queries = gen_queries(N_QUERIES, n);
         perf_rank1(&rs, &queries, n, logn, n);
 
-        let queries = gen_queries(N_QUERIES, rs.n_ones() - 1);
+        let queries = gen_queries(N_QUERIES, rs.count_ones() - 1);
         perf_select1(&rs, &queries, n, logn, n);
 
-        let queries = gen_queries(N_QUERIES, rs.n_zeros() - 1);
+        let queries = gen_queries(N_QUERIES, rs.count_zeros() - 1);
         perf_select0(&rs, &queries, n, logn, n);
     }
 }

--- a/src/bin/perf_rs_wide.rs
+++ b/src/bin/perf_rs_wide.rs
@@ -142,9 +142,9 @@ fn main() {
         let rs = RSWide::new(bv);
 
         println!(
-            "created new bitvector | n_ones: {} | n_zeros: {} | len: {}",
-            rs.n_ones(),
-            rs.n_zeros(),
+            "created new bitvector | count_ones: {} | count_zeros: {} | len: {}",
+            rs.count_ones(),
+            rs.count_zeros(),
             rs.bv_len()
         );
 
@@ -154,10 +154,10 @@ fn main() {
         let queries = gen_queries(N_QUERIES, n);
         perf_get(&rs, &queries, n, logn, n);
 
-        let queries = gen_queries(N_QUERIES, rs.n_ones() - 1);
+        let queries = gen_queries(N_QUERIES, rs.count_ones() - 1);
         perf_select1(&rs, &queries, n, logn, n);
 
-        let queries = gen_queries(N_QUERIES, rs.n_zeros() - 1);
+        let queries = gen_queries(N_QUERIES, rs.count_zeros() - 1);
         perf_select0(&rs, &queries, n, logn, n);
     }
 }

--- a/src/binwt/mod.rs
+++ b/src/binwt/mod.rs
@@ -343,7 +343,7 @@ where
             let tmp = self.bvs[level].rank1_unchecked(cur_i);
 
             cur_i = if symbol {
-                tmp + self.bvs[level].n_zeros()
+                tmp + self.bvs[level].count_zeros()
             } else {
                 cur_i - tmp
             };
@@ -478,7 +478,7 @@ where
             let r_hi = unsafe { bv.rank1_unchecked(cur.range.end) };
 
             if r_hi > r_lo {
-                let offset = bv.n_zeros();
+                let offset = bv.count_zeros();
 
                 let frame = OccsRangeFrame {
                     range: offset + r_lo..offset + r_hi,
@@ -555,7 +555,7 @@ where
         for level in 0..symbol_len {
             let bit = ((repr >> (symbol_len - level - 1)) & 1) == 1;
 
-            let offset = self.bvs[level].n_zeros();
+            let offset = self.bvs[level].count_zeros();
 
             let tmp_p = self.bvs[level].rank1_unchecked(cur_p);
             let tmp_i = self.bvs[level].rank1_unchecked(cur_i);
@@ -608,7 +608,7 @@ where
                 self.bvs[level].rank0(b)
             }?;
 
-            b = rank_b + if bit { self.bvs[level].n_zeros() } else { 0 };
+            b = rank_b + if bit { self.bvs[level].count_zeros() } else { 0 };
 
             rank_path_off.push(rank_b);
         }

--- a/src/bitvector/mod.rs
+++ b/src/bitvector/mod.rs
@@ -41,15 +41,15 @@ impl DataLine {
     }
 
     #[inline]
-    fn n_ones(&self) -> usize {
+    fn count_ones(&self) -> usize {
         self.words
             .iter()
             .fold(0, |a, x| a + x.count_ones() as usize)
     }
 
     #[inline]
-    fn n_zeros(&self) -> usize {
-        512 - self.n_ones()
+    fn count_zeros(&self) -> usize {
+        512 - self.count_ones()
     }
 }
 
@@ -101,8 +101,8 @@ impl RankBin for DataLine {
         rank
     }
 
-    fn n_zeros(&self) -> usize {
-        self.n_zeros()
+    fn count_zeros(&self) -> usize {
+        self.count_zeros()
     }
 }
 
@@ -118,7 +118,7 @@ fn cast_to_u64_slice(data_lines: &[DataLine]) -> &[u64] {
 
 impl SelectBin for DataLine {
     fn select1(&self, i: usize) -> Option<usize> {
-        if i >= self.n_ones() {
+        if i >= self.count_ones() {
             return None;
         }
 
@@ -144,7 +144,7 @@ impl SelectBin for DataLine {
     }
 
     fn select0(&self, i: usize) -> Option<usize> {
-        if i >= self.n_zeros() {
+        if i >= self.count_zeros() {
             return None;
         }
 
@@ -176,7 +176,7 @@ impl SelectBin for DataLine {
 pub struct BitVector {
     data: Box<[DataLine]>,
     n_bits: usize,
-    n_ones: usize,
+    count_ones: usize,
 }
 
 impl BitVector {
@@ -422,7 +422,7 @@ impl BitVector {
     /// assert_eq!(bv.count_ones(), 5);
     /// ```
     pub fn count_ones(&self) -> usize {
-        self.n_ones
+        self.count_ones
     }
 
     /// Counts the number of zeros (bits set to 0) in the bit vector.
@@ -440,7 +440,7 @@ impl BitVector {
     #[inline]
     #[must_use]
     pub fn count_zeros(&self) -> usize {
-        self.len() - self.n_ones
+        self.len() - self.count_ones
     }
 
     /// Returns the number of DataLine in the bitvector
@@ -596,7 +596,7 @@ impl From<BitVectorMut> for BitVector {
         Self {
             data: bvm.data.into_boxed_slice(),
             n_bits: bvm.n_bits,
-            n_ones: bvm.n_ones,
+            count_ones: bvm.count_ones,
         }
     }
 }
@@ -626,7 +626,7 @@ impl From<BitVector> for BitVectorMut {
         Self {
             data: bv.data.into(),
             n_bits: bv.n_bits,
-            n_ones: bv.n_ones,
+            count_ones: bv.count_ones,
         }
     }
 }
@@ -813,7 +813,7 @@ impl<'a> ExactSizeIterator for BitVectorIter<'a> {
 pub struct BitVectorMut {
     data: Vec<DataLine>,
     n_bits: usize,
-    n_ones: usize,
+    count_ones: usize,
 }
 
 impl BitVectorMut {
@@ -931,7 +931,7 @@ impl BitVectorMut {
             if let Some(last) = self.data.last_mut() {
                 last.set_symbol(1, pos_in_line);
             }
-            self.n_ones += 1;
+            self.count_ones += 1;
         }
         self.n_bits += 1;
     }
@@ -968,7 +968,7 @@ impl BitVectorMut {
             return;
         }
 
-        // self.n_ones += bits.count_ones() as usize; taken care in push
+        // self.count_ones += bits.count_ones() as usize; taken care in push
 
         // let pos_in_line: usize = self.n_bits & 511;
         // self.n_bits += len; taken care in push
@@ -1038,10 +1038,10 @@ impl BitVectorMut {
         // SAFETY: check above guarantees we are within the bound
         unsafe {
             if bit && !self.get_unchecked(index) {
-                self.n_ones += 1;
+                self.count_ones += 1;
             }
             if !bit && self.get_unchecked(index) {
-                self.n_ones -= 1;
+                self.count_ones -= 1;
             }
         }
 
@@ -1173,7 +1173,7 @@ impl BitVectorMut {
             return;
         }
 
-        self.n_ones += bits.count_ones() as usize;
+        self.count_ones += bits.count_ones() as usize;
 
         // let mask = if len == 64 {
         //     std::u64::MAX
@@ -1372,7 +1372,7 @@ impl BitVectorMut {
     /// assert_eq!(bv.count_ones(), 2);
     /// ```
     pub fn count_ones(&self) -> usize {
-        self.n_ones
+        self.count_ones
     }
 
     /// Counts the number of zeros (bits set to 0) in the bit vector.
@@ -1392,7 +1392,7 @@ impl BitVectorMut {
     #[inline]
     #[must_use]
     pub fn count_zeros(&self) -> usize {
-        self.len() - self.n_ones
+        self.len() - self.count_ones
     }
 }
 

--- a/src/bitvector/rs_narrow.rs
+++ b/src/bitvector/rs_narrow.rs
@@ -116,14 +116,14 @@ impl RSNarrow {
 
     /// Returns the number of bits set to 1 in the bitvector.
     #[inline(always)]
-    pub fn n_ones(&self) -> usize {
+    pub fn count_ones(&self) -> usize {
         self.rank1(self.bv.len() - 1).unwrap() + self.bv.get(self.bv.len() - 1).unwrap() as usize
     }
 
     /// Returns the number of bits set to 0 in the bitvector.
     #[inline(always)]
-    pub fn n_zeros(&self) -> usize {
-        self.bv.len() - self.n_ones()
+    pub fn count_zeros(&self) -> usize {
+        self.bv.len() - self.count_ones()
     }
 
     #[inline(always)]
@@ -298,14 +298,14 @@ impl RankBin for RSNarrow {
         prefetch_read_NTA(&self.block_rank_pairs, pos >> 8);
     }
 
-    fn n_zeros(&self) -> usize {
-        self.n_zeros()
+    fn count_zeros(&self) -> usize {
+        self.count_zeros()
     }
 }
 
 impl SelectBin for RSNarrow {
     fn select1(&self, i: usize) -> Option<usize> {
-        if i >= self.n_ones() {
+        if i >= self.count_ones() {
             return None;
         }
 
@@ -320,7 +320,7 @@ impl SelectBin for RSNarrow {
     }
 
     fn select0(&self, i: usize) -> Option<usize> {
-        if i >= self.n_zeros() {
+        if i >= self.count_zeros() {
             return None;
         }
 

--- a/src/bitvector/rs_wide.rs
+++ b/src/bitvector/rs_wide.rs
@@ -18,7 +18,7 @@ pub struct RSWide {
     bv: BitVector,
     superblock_metadata: Box<[u128]>, // in each u128 we store the pair (superblock, <7 blocks>) like so |L1  |L2|L2|L2|L2|L2|L2|L2|
     select_samples: [Box<[usize]>; 2],
-    n_zeros: usize,
+    count_zeros: usize,
 }
 
 impl RSWide {
@@ -56,7 +56,7 @@ impl RSWide {
                 // println!("metadata so far: {:0>128b}", cur_metadata);
             }
 
-            word_pop += dl.n_ones() as u128;
+            word_pop += dl.count_ones() as u128;
 
             if (total_rank + word_pop) / SELECT_ONES_PER_HINT as u128 > cur_hint_1 {
                 //we insert a new hint for 1
@@ -64,7 +64,7 @@ impl RSWide {
                 cur_hint_1 += 1;
             }
 
-            zeros_so_far += dl.n_zeros() as u128;
+            zeros_so_far += dl.count_zeros() as u128;
             if (zeros_so_far / SELECT_ZEROS_PER_HINT as u128) > cur_hint_0 {
                 //we insert a new hint for 0
                 select_samples[0].push(b / 8);
@@ -107,7 +107,7 @@ impl RSWide {
         select_samples[0].push(superblock_metadata.len() - 1);
         select_samples[1].push(superblock_metadata.len() - 1);
 
-        let n_zeros = bv.len() - total_rank as usize;
+        let count_zeros = bv.len() - total_rank as usize;
 
         Self {
             bv,
@@ -118,20 +118,20 @@ impl RSWide {
                 .collect::<Vec<_>>()
                 .try_into()
                 .unwrap(),
-            n_zeros,
+            count_zeros,
         }
     }
 
     /// Returns the number of bits set to 1 in the bitvector.
     #[inline(always)]
-    pub fn n_ones(&self) -> usize {
-        self.bv.len() - self.n_zeros()
+    pub fn count_ones(&self) -> usize {
+        self.bv.len() - self.count_zeros()
     }
 
     /// Returns the number of bits set to 0 in the bitvector.
     #[inline(always)]
-    pub fn n_zeros(&self) -> usize {
-        self.n_zeros
+    pub fn count_zeros(&self) -> usize {
+        self.count_zeros
     }
 
     /// Returns the number of bits in the bitvector.
@@ -324,8 +324,8 @@ impl RankBin for RSWide {
         prefetch_read_NTA(&self.superblock_metadata, superblock);
     }
 
-    fn n_zeros(&self) -> usize {
-        self.n_zeros()
+    fn count_zeros(&self) -> usize {
+        self.count_zeros()
     }
 }
 
@@ -353,7 +353,7 @@ impl SelectBin for RSWide {
     ///
     /// ```
     fn select1(&self, i: usize) -> Option<usize> {
-        if i >= self.n_ones() {
+        if i >= self.count_ones() {
             return None;
         }
 
@@ -399,7 +399,7 @@ impl SelectBin for RSWide {
     ///
     /// ```
     fn select0(&self, i: usize) -> Option<usize> {
-        if i >= self.n_zeros() {
+        if i >= self.count_zeros() {
             return None;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ pub trait RankBin {
         i - self.rank1_unchecked(i)
     }
 
-    fn n_zeros(&self) -> usize;
+    fn count_zeros(&self) -> usize;
 }
 
 /// A trait for the support of `select` query over the binary alphabet.


### PR DESCRIPTION
This PR resolves issue #7 and achieves consistent naming both internally within QWT as well as with rsdict.