### PR TITLE
support stable Rust on AArch64 with prefetch

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(
-    all(feature = "prefetch", target_arch = "aarch64"),
-    feature(stdarch_aarch64_prefetch)
-)]
 
 pub use mem_dbg;
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -23,10 +23,12 @@ pub fn prefetch_read_NTA<T>(data: &[T], offset: usize) {
 
     #[cfg(all(feature = "prefetch", target_arch = "aarch64"))]
     {
-        use core::arch::aarch64::{_prefetch, _PREFETCH_LOCALITY0, _PREFETCH_READ};
-
         unsafe {
-            _prefetch(_p, _PREFETCH_READ, _PREFETCH_LOCALITY0);
+            std::arch::asm!(
+                "prfm pldl1strm, [{}]",
+                in(reg) _p,
+                options(nostack, readonly, preserves_flags)
+            );
         }
     }
 }


### PR DESCRIPTION
Replace stdarch_aarch64_prefetch feature with inline assembly to to support AArch64 prefetch with stable Rust.
Resolves issue #19.

**Please test this before merging, I do not have access to an AArch64 machine!**