### PR TITLE
Rename RSWide::bv_len to RSWide::len and add this to RSNarrow as well

### DIFF
--- a/src/bin/perf_rs_wide.rs
+++ b/src/bin/perf_rs_wide.rs
@@ -145,7 +145,7 @@ fn main() {
             "created new bitvector | count_ones: {} | count_zeros: {} | len: {}",
             rs.count_ones(),
             rs.count_zeros(),
-            rs.bv_len()
+            rs.len()
         );
 
         let queries = gen_queries(N_QUERIES, n);

--- a/src/bitvector/rs_narrow.rs
+++ b/src/bitvector/rs_narrow.rs
@@ -108,6 +108,12 @@ impl RSNarrow {
         }
     }
 
+    /// Returns the number of bits in the bitvector.
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.bv.len()
+    }
+
     /// Returns a reference to the underlying bitvector.
     #[inline]
     pub fn bit_vector(&self) -> &BitVector {

--- a/src/bitvector/rs_wide.rs
+++ b/src/bitvector/rs_wide.rs
@@ -136,7 +136,7 @@ impl RSWide {
 
     /// Returns the number of bits in the bitvector.
     #[inline(always)]
-    pub fn bv_len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.bv.len()
     }
 


### PR DESCRIPTION
Part of the ergonomics improvements requested in #10.
Firstly, it is inconsistent that RSWide has a bv_len() method but RSNarrow so I added this as well to make the two consistent to use especially when switching between them.
Secondly, because there is no other len() method and there is already a rustdoc comment explaining that the length of the bitvector is meant, I think naming it just "len" instead of "bv_len" is simpler and I don't expect would ever cause misunderstandings.
Existing code using bv_len would need to be updated so it would require a minor version bump (because mayor version is 0).