### PR TITLE
Add guided range-successor queries and fused 4-symbol rank

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 ## TODO
 - Use a binary vector at the first level when log sigma is odd.
 - Implement an efficient iterator over a Wavelet Tree.
-- Implement a binary wavelet tree.
+  - Partially addressed by `RangeDistinctIter` (fixed-stack distinct-symbol
+    enumerator over a row range). A full position / value iterator is still open.
+- Implement a binary wavelet tree. (`binwt` remains a stub.)
 - Replace From with TryFrom
 - Implement DoubleEndedIterator for all the collections

--- a/examples/perf_darray.rs
+++ b/examples/perf_darray.rs
@@ -1,8 +1,7 @@
+use mem_dbg::{MemSize, SizeFlags};
 use qwt::perf_and_test_utils::{
     gen_queries, gen_strictly_increasing_sequence, type_of, TimingQueries,
 };
-
-use mem_dbg::{MemSize, SizeFlags};
 use qwt::{DArray, SelectBin};
 
 fn main() {

--- a/examples/perf_rs_narrow.rs
+++ b/examples/perf_rs_narrow.rs
@@ -1,9 +1,7 @@
 use mem_dbg::{MemSize, SizeFlags};
-use qwt::{
-    narrow::RS,
-    perf_and_test_utils::{gen_queries, type_of, TimingQueries},
-    RankBin, SelectBin,
-};
+use qwt::narrow::RS;
+use qwt::perf_and_test_utils::{gen_queries, type_of, TimingQueries};
+use qwt::{RankBin, SelectBin};
 
 const N_RUNS: usize = 5;
 const N_QUERIES: usize = 10_000_000;

--- a/examples/perf_rs_qvector.rs
+++ b/examples/perf_rs_qvector.rs
@@ -1,7 +1,6 @@
 use mem_dbg::{MemSize, SizeFlags};
 use qwt::perf_and_test_utils::{gen_queries, type_of, TimingQueries};
 use qwt::RSQVector256;
-
 // traits
 use qwt::{AccessQuad, RankQuad, SelectQuad};
 

--- a/examples/perf_rs_wide.rs
+++ b/examples/perf_rs_wide.rs
@@ -1,9 +1,7 @@
 use mem_dbg::{MemSize, SizeFlags};
-use qwt::{
-    bitvector::wide::RS,
-    perf_and_test_utils::{gen_queries, type_of, TimingQueries},
-    AccessBin, RankBin, SelectBin,
-};
+use qwt::bitvector::wide::RS;
+use qwt::perf_and_test_utils::{gen_queries, type_of, TimingQueries};
+use qwt::{AccessBin, RankBin, SelectBin};
 
 const N_RUNS: usize = 5;
 const N_QUERIES: usize = 10_000_000;

--- a/examples/perf_wavelet_tree.rs
+++ b/examples/perf_wavelet_tree.rs
@@ -1,19 +1,18 @@
-use std::{fs, path::Path};
-
 use clap::Parser;
 use mem_dbg::{MemSize, SizeFlags};
+use qwt::perf_and_test_utils::{
+    gen_queries, gen_rank_queries, gen_select_queries, random_range_queries, type_of, TimingQueries,
+};
+use qwt::quadwt::RSforWT;
+use qwt::utils::{msb, text_remap};
 use qwt::{
-    perf_and_test_utils::{
-        gen_queries, gen_rank_queries, gen_select_queries, random_range_queries, type_of,
-        TimingQueries,
-    },
-    quadwt::RSforWT,
-    utils::{msb, text_remap},
     AccessUnsigned, HQWT256Pfs, HQWT512Pfs, HuffQWaveletTree, OccsRangeUnsigned, QWT256Pfs,
     QWT512Pfs, QWaveletTree, RankUnsigned, SelectUnsigned, HQWT256, HQWT512, HWT, QWT256, QWT512,
     WT,
 };
 use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
 
 const N_RUNS: usize = 10;
 

--- a/src/binwt/mod.rs
+++ b/src/binwt/mod.rs
@@ -1,20 +1,16 @@
-use std::{
-    collections::HashMap,
-    marker::PhantomData,
-    ops::{Bound, Range, RangeBounds},
+use crate::quadwt::huffqwt::PrefixCode;
+use crate::utils::{msb, stable_partition_of_2, stable_partition_of_2_with_codes};
+use crate::{
+    AccessUnsigned, BinWTSupport, BitVector, BitVectorMut, OccsRangeUnsigned, RankUnsigned,
+    SelectUnsigned, WTIndexable, WTIterator,
 };
-
 use mem_dbg::{MemDbg, MemSize};
 use minimum_redundancy::{BitsPerFragment, Coding};
 use num_traits::AsPrimitive;
 use serde::{Deserialize, Serialize};
-
-use crate::{
-    quadwt::huffqwt::PrefixCode,
-    utils::{msb, stable_partition_of_2, stable_partition_of_2_with_codes},
-    AccessUnsigned, BinWTSupport, BitVector, BitVectorMut, OccsRangeUnsigned, RankUnsigned,
-    SelectUnsigned, WTIndexable, WTIterator,
-};
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::ops::{Bound, Range, RangeBounds};
 
 pub trait BinRSforWT: From<BitVector> + BinWTSupport + MemSize + MemDbg + Default {}
 impl<T> BinRSforWT for T where T: From<BitVector> + BinWTSupport + MemSize + MemDbg + Default {}
@@ -31,7 +27,7 @@ pub struct WaveletTree<T, BRS, const COMPRESSED: bool = false> {
     phantom_data: PhantomData<T>,
 }
 
-struct LenInfo(usize, u32); //symbol, len
+struct LenInfo(usize, u32); // symbol, len
 
 #[allow(clippy::identity_op)]
 fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCode> {
@@ -47,7 +43,7 @@ fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCod
 
     let mut c = vec![0; alph_size];
     let mut assignments = vec![PrefixCode { content: 0, len: 0 }; sigma + 1];
-    let mut m = 1; //how many codes we have so far
+    let mut m = 1; // how many codes we have so far
     let mut l = 0;
 
     for j in 0..alph_size {
@@ -62,8 +58,8 @@ fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCod
             l += 1;
         }
 
-        //the codes are stored in lexicographic order of their reverse codes,
-        //now we get the actual one we need by reversing it
+        // the codes are stored in lexicographic order of their reverse codes,
+        // now we get the actual one we need by reversing it
         let mut reversed_code = 0;
         for t in 0..l {
             reversed_code |= ((c[j] >> t) & 1) << (l - t - 1);
@@ -128,9 +124,9 @@ where
         let sigma = *sequence.iter().max().unwrap();
 
         if COMPRESSED {
-            //we craft the codes
+            // we craft the codes
 
-            //count symbol frequences
+            // count symbol frequences
             let freqs = sequence.iter().fold(HashMap::new(), |mut map, &c| {
                 *map.entry(c.as_()).or_insert(0u32) += 1;
                 map
@@ -155,7 +151,7 @@ where
                 }
             }
 
-            //sort codes to make it easier to search
+            // sort codes to make it easier to search
             for v in decoder.iter_mut() {
                 v.sort_by_key(|(x, _)| *x)
             }
@@ -169,7 +165,7 @@ where
             sig = Some(sigma);
         }
 
-        //populate bvs
+        // populate bvs
         let mut bvs = Vec::with_capacity(n_levels);
         let mut lens = Vec::with_capacity(n_levels);
 
@@ -266,7 +262,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{WT, HWT};
+    /// use qwt::{HWT, WT};
     ///
     /// let data = vec![1u8, 0, 1, 0, 255, 4, 5, 3];
     ///
@@ -294,7 +290,10 @@ where
     ///
     /// assert_eq!(wt.iter().collect::<Vec<_>>(), data);
     ///
-    /// assert_eq!(wt.iter().rev().collect::<Vec<_>>(), data.into_iter().rev().collect::<Vec<_>>());
+    /// assert_eq!(
+    ///     wt.iter().rev().collect::<Vec<_>>(),
+    ///     data.into_iter().rev().collect::<Vec<_>>()
+    /// );
     /// ```
     pub fn iter(
         &self,

--- a/src/bitvector/mod.rs
+++ b/src/bitvector/mod.rs
@@ -6,11 +6,8 @@
 //!
 //! For both data structures, it is possible to iterate over bits or positions of bits set either to zero or one.
 
-use crate::{
-    utils::{prefetch_read_NTA, select_in_word},
-    AccessBin, RankBin, SelectBin,
-};
-
+use crate::utils::{prefetch_read_NTA, select_in_word};
+use crate::{AccessBin, RankBin, SelectBin};
 use mem_dbg::{MemDbg, MemSize};
 use serde::{Deserialize, Serialize};
 
@@ -24,14 +21,14 @@ struct DataLine {
 }
 
 impl DataLine {
-    //set symbol to position `i`
+    // set symbol to position `i`
     #[inline]
     fn set_symbol(&mut self, symbol: u64, i: usize) {
         assert!(i < 512);
 
         let mask: u64 = 1 << (i % 64);
-        self.words[i >> 6] ^= self.words[i >> 6] & mask; //zero out the position
-        self.words[i >> 6] ^= (symbol & 1) << (i % 64); //set position to symbol
+        self.words[i >> 6] ^= self.words[i >> 6] & mask; // zero out the position
+        self.words[i >> 6] ^= (symbol & 1) << (i % 64); // set position to symbol
     }
 
     #[inline]
@@ -107,7 +104,7 @@ impl RankBin for DataLine {
 }
 
 fn cast_to_u64_slice(data_lines: &[DataLine]) -> &[u64] {
-    //WARNING: this works because DataLine is aligned
+    // WARNING: this works because DataLine is aligned
     unsafe {
         let len = data_lines.len().checked_mul(8).unwrap();
         let ptr = data_lines.as_ptr();
@@ -128,7 +125,7 @@ impl SelectBin for DataLine {
     #[inline(always)]
     unsafe fn select1_unchecked(&self, i: usize) -> usize {
         let mut off = 0;
-        let mut rank = 0; //rank so far
+        let mut rank = 0; // rank so far
 
         for w in 0..8 {
             let kp = self.words.get_unchecked(w).count_ones();
@@ -188,9 +185,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use qwt::{BitVector, AccessBin};
+    /// use qwt::{AccessBin, BitVector};
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     /// assert_eq!(bv.get(1), Some(false));
     ///
@@ -226,9 +223,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use qwt::{BitVector};
+    /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// // This is unsafe because it does not perform bounds checking
@@ -249,7 +246,7 @@ impl BitVector {
     /// ```
     /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// // Get the 64-bit word at index 0
@@ -269,12 +266,12 @@ impl BitVector {
     /// ```
     /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,4,5,64,129];
+    /// let v = vec![0, 2, 3, 4, 5, 64, 129];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// // Get all 64-bit words
     /// let words = bv.words();
-    /// assert_eq!(words, [0b111101,0b1,0b10]);
+    /// assert_eq!(words, [0b111101, 0b1, 0b10]);
     /// ```
     #[must_use]
     #[inline]
@@ -291,7 +288,6 @@ impl BitVector {
     ///
     /// let vv: Vec<usize> = vec![0, 63, 128, 129, 254, 1026];
     /// let bv: BitVector = vv.iter().copied().collect();
-    ///
     /// ```
     #[must_use]
     pub fn ones(&self) -> BitVectorBitPositionsIter<'_, true> {
@@ -321,8 +317,8 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use qwt::BitVector;
     /// use qwt::perf_and_test_utils::negate_vector;
+    /// use qwt::BitVector;
     ///
     /// let vv: Vec<usize> = vec![0, 63, 128, 129, 254, 1026];
     /// let bv: BitVector = vv.iter().copied().collect();
@@ -348,7 +344,7 @@ impl BitVector {
     /// ```
     /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,5];
+    /// let v = vec![0, 2, 3, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// let mut iter = bv.iter();
@@ -379,7 +375,7 @@ impl BitVector {
     /// ```
     /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// assert!(!bv.is_empty());
@@ -400,7 +396,7 @@ impl BitVector {
     /// ```
     /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// assert_eq!(bv.len(), 6);
@@ -416,7 +412,7 @@ impl BitVector {
     /// ```
     /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// assert_eq!(bv.count_ones(), 5);
@@ -432,7 +428,7 @@ impl BitVector {
     /// ```
     /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// assert_eq!(bv.count_zeros(), 1);
@@ -461,9 +457,9 @@ impl AccessBin for BitVector {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{BitVector, AccessBin};
+    /// use qwt::{AccessBin, BitVector};
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// assert_eq!(bv.get(5), Some(true));
@@ -486,12 +482,12 @@ impl AccessBin for BitVector {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{BitVector, AccessBin};
+    /// use qwt::{AccessBin, BitVector};
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
-    /// assert_eq!(unsafe{bv.get_unchecked(5)}, true);
+    /// assert_eq!(unsafe { bv.get_unchecked(5) }, true);
     /// ```
 
     #[inline(always)]
@@ -580,7 +576,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use qwt::{BitVector, BitVectorMut, AccessBin};
+/// use qwt::{AccessBin, BitVector, BitVectorMut};
 ///
 /// let mut bvm = BitVectorMut::new();
 /// bvm.push(true);
@@ -608,9 +604,9 @@ impl From<BitVectorMut> for BitVector {
 /// # Examples
 ///
 /// ```
-/// use qwt::{BitVector, BitVectorMut, AccessBin};
+/// use qwt::{AccessBin, BitVector, BitVectorMut};
 ///
-/// let v = vec![0,2,3,4,5];
+/// let v = vec![0, 2, 3, 4, 5];
 /// let mut bv: BitVector = v.into_iter().collect();
 ///
 /// // Convert immutable BitVector to mutable BitVectorMut
@@ -879,10 +875,10 @@ impl BitVectorMut {
     /// # Examples
     ///
     /// ```
-    /// use qwt::{BitVectorMut, BitVector};
+    /// use qwt::{BitVector, BitVectorMut};
     ///
     /// let v = [0b1110];
-    /// let bv: BitVector = BitVectorMut::from_packed_data(&v,4).into();
+    /// let bv: BitVector = BitVectorMut::from_packed_data(&v, 4).into();
     /// assert_eq!(bv.words()[0], 0b1110);
     /// ```
     #[must_use]
@@ -909,7 +905,7 @@ impl BitVectorMut {
     /// # Example
     ///
     /// ```
-    /// use qwt::{BitVectorMut, AccessBin};
+    /// use qwt::{AccessBin, BitVectorMut};
     ///
     /// let mut bv = BitVectorMut::new();
     /// bv.push(true);
@@ -952,10 +948,9 @@ impl BitVectorMut {
     /// use qwt::BitVectorMut;
     ///
     /// let mut bv = BitVectorMut::with_capacity(7);
-    /// bv.append_bits(0b101, 3);  // appends 101
-    /// bv.append_bits(0b0110, 4); // appends 0110  
+    /// bv.append_bits(0b101, 3); // appends 101
+    /// bv.append_bits(0b0110, 4); // appends 0110
     ///
-    ///         
     /// assert_eq!(bv.len(), 7);
     /// assert_eq!(bv.get_bits(0, 3), Some(5));
     /// ```
@@ -996,7 +991,7 @@ impl BitVectorMut {
     /// # Examples
     ///
     /// ```
-    /// use qwt::{BitVectorMut, AccessBin};
+    /// use qwt::{AccessBin, BitVectorMut};
     ///
     /// let mut bv = BitVectorMut::with_capacity(10);
     /// bv.extend_with_zeros(10);
@@ -1019,7 +1014,7 @@ impl BitVectorMut {
     /// # Examples
     ///
     /// ```
-    /// use qwt::{BitVectorMut, AccessBin};
+    /// use qwt::{AccessBin, BitVectorMut};
     ///
     /// let mut bv = BitVectorMut::with_capacity(2);
     /// bv.push(true);
@@ -1058,7 +1053,7 @@ impl BitVectorMut {
     /// # Examples
     ///
     /// ```
-    /// use qwt::{BitVectorMut, AccessBin};
+    /// use qwt::{AccessBin, BitVectorMut};
     ///
     /// let mut bv = BitVectorMut::with_capacity(6);
     /// bv.append_bits(0b111101, 6); // Appends 111101 note that we append bits from right to left
@@ -1258,8 +1253,8 @@ impl BitVectorMut {
     /// # Examples
     ///
     /// ```
-    /// use qwt::BitVectorMut;
     /// use qwt::perf_and_test_utils::negate_vector;
+    /// use qwt::BitVectorMut;
     ///
     /// let vv: Vec<usize> = vec![0, 63, 128, 129, 254, 1026];
     /// let bv: BitVectorMut = vv.iter().copied().collect();
@@ -1402,7 +1397,7 @@ impl AccessBin for BitVectorMut {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{BitVectorMut, AccessBin};
+    /// use qwt::{AccessBin, BitVectorMut};
     ///
     /// let mut bv = BitVectorMut::with_capacity(10);
     /// bv.extend_with_zeros(10);
@@ -1425,11 +1420,11 @@ impl AccessBin for BitVectorMut {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{BitVectorMut, AccessBin};
+    /// use qwt::{AccessBin, BitVectorMut};
     ///
     /// let mut bv = BitVectorMut::with_capacity(10);
     /// bv.extend_with_zeros(10);
-    /// assert_eq!(unsafe{bv.get_unchecked(8)}, false);
+    /// assert_eq!(unsafe { bv.get_unchecked(8) }, false);
     /// ```
 
     #[inline(always)]
@@ -1448,14 +1443,13 @@ impl Extend<bool> for BitVectorMut {
         }
     }
 
-    /* Nigthly
-        fn extend_one(&mut self, item: bool) {
-            self.push(item);
-        }
-        fn extend_reserve(&mut self, additional: usize) {
-            self.data.reserve
-        }
-    */
+    // Nigthly
+    // fn extend_one(&mut self, item: bool) {
+    // self.push(item);
+    // }
+    // fn extend_reserve(&mut self, additional: usize) {
+    // self.data.reserve
+    // }
 }
 
 /// Implements creating a `BitVectorMut` from an iterator over `bool` values.
@@ -1513,7 +1507,7 @@ impl FromIterator<usize> for BitVectorMut {
 /// # Examples
 ///
 /// ```
-/// use qwt::{BitVectorMut, AccessBin};
+/// use qwt::{AccessBin, BitVectorMut};
 ///
 /// let mut bv = BitVectorMut::new();
 ///

--- a/src/bitvector/narrow.rs
+++ b/src/bitvector/narrow.rs
@@ -3,15 +3,12 @@
 //!
 //! This implementation is inspired by the C++ implementation by [Giuseppe Ottaviano](https://github.com/ot/succinct/blob/master/rs_bit_vector.cpp).
 
-use crate::{
-    utils::{prefetch_read_NTA, select_in_word},
-    AccessBin, BitVector, RankBin, SelectBin,
-};
-
+use crate::utils::{prefetch_read_NTA, select_in_word};
+use crate::{AccessBin, BitVector, RankBin, SelectBin};
 use mem_dbg::{MemDbg, MemSize};
 use serde::{Deserialize, Serialize};
 
-//block_rank_pairs layout
+// block_rank_pairs layout
 //|superblock0|block0|superblock1|block1...
 const BLOCK_SIZE: usize = 8; // in 64bit words
 
@@ -59,7 +56,7 @@ impl RS {
                 next_rank += word_pop;
                 cur_subrank += word_pop;
 
-                //check for samples
+                // check for samples
                 if next_rank / SELECT_ONES_PER_HINT as u64 > cur_hint_1 {
                     select_samples[1].push(b);
                     cur_hint_1 += 1;
@@ -174,7 +171,7 @@ impl RS {
         // rank = self.block_rank(position);
         // println!("selected block {} with rank {}", position, rank);
 
-        //now we examine sub_blocks
+        // now we examine sub_blocks
         position *= BLOCK_SIZE;
 
         // println!("now sub_blocks");
@@ -217,7 +214,7 @@ impl RS {
         // rank = position * max_rank_for_block - self.block_rank(position);
         // println!("selected block {} with rank0 {}", position, position * max_rank_for_block - self.block_rank(position));
 
-        //now we examine sub_blocks
+        // now we examine sub_blocks
         position *= BLOCK_SIZE;
 
         let max_rank_for_subblock = 64;

--- a/src/bitvector/tests.rs
+++ b/src/bitvector/tests.rs
@@ -76,8 +76,8 @@ fn test_from_iter() {
 
     assert_eq!(bv, bv2);
 
-    /* Note: if last bits are zero, the bit vector may differ
-    because we are inserting only position of ones */
+    // Note: if last bits are zero, the bit vector may differ
+    // because we are inserting only position of ones
     let bv2: BitVectorMut = (0..n).filter(|x| x % 2 == 0).collect();
 
     assert_eq!(bv, bv2);

--- a/src/bitvector/wide.rs
+++ b/src/bitvector/wide.rs
@@ -1,12 +1,12 @@
 //! Implements data structure to support `rank` and `select` queries on a binary vector with 512-bit blocks.
 //!
 //! This implementation is inspired by [this paper by Florian Kurpicz] (https://link.springer.com/chapter/10.1007/978-3-031-20643-6_19)
-use crate::{utils::prefetch_read_NTA, AccessBin, BitVector, RankBin, SelectBin};
-
+use crate::utils::prefetch_read_NTA;
+use crate::{AccessBin, BitVector, RankBin, SelectBin};
 use mem_dbg::{MemDbg, MemSize};
 use serde::{Deserialize, Serialize};
 
-//superblock is 44 bits, blocks are (BLOCK_SIZE-1) * 12 bits each
+// superblock is 44 bits, blocks are (BLOCK_SIZE-1) * 12 bits each
 const BLOCK_SIZE: usize = 8; // 8 64bit words for each block
 const SUPERBLOCK_SIZE: usize = 8 * BLOCK_SIZE; // 8 blocks for each superblock (this is the size in u64 words)
 
@@ -16,7 +16,7 @@ const SELECT_ZEROS_PER_HINT: usize = SELECT_ONES_PER_HINT;
 #[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize, MemSize, MemDbg, Debug)]
 pub struct RS {
     bv: BitVector,
-    superblock_metadata: Box<[u128]>, // in each u128 we store the pair (superblock, <7 blocks>) like so |L1  |L2|L2|L2|L2|L2|L2|L2|
+    superblock_metadata: Box<[u128]>, /* in each u128 we store the pair (superblock, <7 blocks>) like so |L1  |L2|L2|L2|L2|L2|L2|L2| */
     select_samples: [Box<[usize]>; 2],
     count_zeros: usize,
 }
@@ -38,7 +38,7 @@ impl RS {
 
         for (b, &dl) in bv.data.iter().enumerate() {
             if b % 8 == 0 {
-                //we are at the start of new superblock, so we push the rank so far
+                // we are at the start of new superblock, so we push the rank so far
                 total_rank += word_pop;
                 word_pop = 0;
 
@@ -47,8 +47,8 @@ impl RS {
                 // println!("new superblock! added metadata, total rank: {}", total_rank);
                 // println!("metadata so far: {:0>128b}", cur_metadata);
             } else {
-                //we ignore the frist block beacuse it would be 0
-                //if we are not at the start of a new superblock, we are at the start of a block
+                // we ignore the frist block beacuse it would be 0
+                // if we are not at the start of a new superblock, we are at the start of a block
                 cur_metadata <<= 12;
                 cur_metadata |= word_pop;
 
@@ -59,26 +59,26 @@ impl RS {
             word_pop += dl.count_ones() as u128;
 
             if (total_rank + word_pop) / SELECT_ONES_PER_HINT as u128 > cur_hint_1 {
-                //we insert a new hint for 1
+                // we insert a new hint for 1
                 select_samples[1].push(b / 8);
                 cur_hint_1 += 1;
             }
 
             zeros_so_far += dl.count_zeros() as u128;
             if (zeros_so_far / SELECT_ZEROS_PER_HINT as u128) > cur_hint_0 {
-                //we insert a new hint for 0
+                // we insert a new hint for 0
                 select_samples[0].push(b / 8);
                 cur_hint_0 += 1;
             }
 
             if (b + 1) % 8 == 0 {
-                //next round we reset the metadata so we push it now
+                // next round we reset the metadata so we push it now
                 superblock_metadata.push(cur_metadata);
                 // println!("Pushed superblock!");
             }
         }
 
-        //we flush the remainder in total rank
+        // we flush the remainder in total rank
         total_rank += word_pop;
 
         let left: usize = bv.data.len() % 8;
@@ -94,7 +94,7 @@ impl RS {
             // println!("Pushed superblock!");
         }
 
-        //we push last superblock containing only the last total_rank
+        // we push last superblock containing only the last total_rank
         cur_metadata = 0;
         cur_metadata |= total_rank;
         cur_metadata <<= 128 - 44;
@@ -103,7 +103,7 @@ impl RS {
 
         superblock_metadata.shrink_to_fit();
 
-        //guard at the end
+        // guard at the end
         select_samples[0].push(superblock_metadata.len() - 1);
         select_samples[1].push(superblock_metadata.len() - 1);
 
@@ -163,7 +163,7 @@ impl RS {
         self.bv.prefetch_line(pos / 512);
     }
 
-    ///returns the total rank1 up to `sub_block`
+    /// returns the total rank1 up to `sub_block`
     #[inline(always)]
     fn sub_block_rank(&self, sub_block: usize) -> usize {
         let mut result = 0;
@@ -199,7 +199,7 @@ impl RS {
         position = hint_start - 1;
         // println!("selected superblock {} with rank {}", position, self.superblock_rank(position););
 
-        //now we examine sub_blocks
+        // now we examine sub_blocks
         position *= SUPERBLOCK_SIZE / BLOCK_SIZE;
 
         // println!("now sub_blocks");
@@ -209,7 +209,7 @@ impl RS {
                 position += j - 1;
                 break;
             }
-            //if we didn't stop before
+            // if we didn't stop before
             if j == 7 {
                 position += j;
             }
@@ -242,7 +242,7 @@ impl RS {
         position = hint_start - 1;
         // println!("selected block {} with rank0 {}", position, position * max_rank_for_block - self.superblock_rank(position));
 
-        //now we examine sub_blocks
+        // now we examine sub_blocks
         position *= SUPERBLOCK_SIZE / BLOCK_SIZE;
 
         let max_rank_for_subblock = BLOCK_SIZE * 64;
@@ -335,8 +335,8 @@ impl SelectBin for RS {
     /// Returns `None` if the data structure has no such element (i >= maximum rank1)
     /// # Examples
     /// ```
-    /// use qwt::{BitVector, wide::RS, SelectBin};
-    ///
+    /// use qwt::wide::RS;
+    /// use qwt::{BitVector, SelectBin};
     ///
     /// let vv: Vec<usize> = vec![3, 5, 8, 128, 129, 513, 1000, 1024, 1025];
     /// let bv: BitVector = vv.iter().copied().collect();
@@ -350,7 +350,6 @@ impl SelectBin for RS {
     /// assert_eq!(rs.select1(5), Some(513));
     /// assert_eq!(rs.select1(8), Some(1025));
     /// assert_eq!(rs.select1(9), None);
-    ///
     /// ```
     fn select1(&self, i: usize) -> Option<usize> {
         if i >= self.count_ones() {
@@ -380,8 +379,9 @@ impl SelectBin for RS {
     /// Returns `None` if the data structure has no such element (i >= maximum rank0)
     /// # Examples
     /// ```
-    /// use qwt::{BitVector, wide::RS, SelectBin};
     /// use qwt::perf_and_test_utils::negate_vector;
+    /// use qwt::wide::RS;
+    /// use qwt::{BitVector, SelectBin};
     ///
     /// let vv: Vec<usize> = vec![3, 5, 8, 128, 129, 513, 1000, 1024, 1025];
     /// let bv: BitVector = vv.iter().copied().collect();
@@ -396,7 +396,6 @@ impl SelectBin for RS {
     /// assert_eq!(rs.select0(125), Some(130));
     /// assert_eq!(rs.select0(1016), Some(1023));
     /// assert_eq!(rs.select0(1017), None);
-    ///
     /// ```
     fn select0(&self, i: usize) -> Option<usize> {
         if i >= self.count_zeros() {

--- a/src/darray/mod.rs
+++ b/src/darray/mod.rs
@@ -19,8 +19,7 @@
 //! Without this support, the query [`SelectBin::select0`] will panic.
 //!
 //! ```
-//! use qwt::DArray;
-//! use qwt::{SelectBin, RankBin};
+//! use qwt::{DArray, RankBin, SelectBin};
 //!
 //! let vv: Vec<usize> = vec![0, 12, 33, 42, 55, 61, 1000];
 //! let da: DArray<false> = vv.into_iter().collect();
@@ -53,18 +52,14 @@
 //! the position of the first one in its block and start a linear scan from that position
 //! looking for the i-th occurrence of 1. If the block is sparse, the answer is stored in vector
 //! *overflow_positions*.
-//!
 // TODO! //! Space overhead is TODO!
-//!
 //! These three vectors are stored in a private struct `Inventories`.
 //! The const generic BITS in this struct allows us to build and store these vectors to support
 //! `select0` as well.
 
 use crate::bitvector::{BitVectorBitPositionsIter, BitVectorIter};
 use crate::utils::select_in_word;
-use crate::BitVector;
-use crate::{AccessBin, SelectBin};
-
+use crate::{AccessBin, BitVector, SelectBin};
 use mem_dbg::{MemDbg, MemSize};
 use serde::{Deserialize, Serialize};
 #[cfg(target_arch = "x86_64")]
@@ -191,8 +186,8 @@ impl<const SELECT0_SUPPORT: bool> DArray<SELECT0_SUPPORT> {
     /// ```
     /// use qwt::{DArray, SelectBin};
     ///
-    /// let v = vec![0,2,3,4,5];
-    /// let da: DArray::<true> = v.into_iter().collect(); // <true> to support the select0 query
+    /// let v = vec![0, 2, 3, 4, 5];
+    /// let da: DArray<true> = v.into_iter().collect(); // <true> to support the select0 query
     ///
     /// assert_eq!(da.select1(2), Some(3));
     /// assert_eq!(da.select0(0), Some(1));
@@ -254,8 +249,8 @@ impl<const SELECT0_SUPPORT: bool> DArray<SELECT0_SUPPORT> {
     /// # Examples
     ///
     /// ```
-    /// use qwt::DArray;
     /// use qwt::perf_and_test_utils::negate_vector;
+    /// use qwt::DArray;
     ///
     /// let vv: Vec<usize> = vec![0, 63, 128, 129, 254, 1026];
     /// let da: DArray = vv.iter().copied().collect();
@@ -281,7 +276,7 @@ impl<const SELECT0_SUPPORT: bool> DArray<SELECT0_SUPPORT> {
     /// ```
     /// use qwt::DArray;
     ///
-    /// let v = vec![0,2,3,5];
+    /// let v = vec![0, 2, 3, 5];
     /// let da: DArray = v.into_iter().collect();
     ///
     /// let mut iter = da.iter();
@@ -429,10 +424,10 @@ impl<const SELECT0_SUPPORT: bool> AccessBin for DArray<SELECT0_SUPPORT> {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{DArray, AccessBin};
+    /// use qwt::{AccessBin, DArray};
     ///
-    /// let v = vec![0,2,3,4,5];
-    /// let da: DArray = v.into_iter().collect();;
+    /// let v = vec![0, 2, 3, 4, 5];
+    /// let da: DArray = v.into_iter().collect();
     ///
     /// assert_eq!(da.get(5), Some(true));
     /// assert_eq!(da.get(1), Some(false));
@@ -451,11 +446,11 @@ impl<const SELECT0_SUPPORT: bool> AccessBin for DArray<SELECT0_SUPPORT> {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{DArray, AccessBin};
+    /// use qwt::{AccessBin, DArray};
     ///
-    /// let v = vec![0,2,3,4,5];
-    /// let da: DArray = v.into_iter().collect();;
-    /// assert_eq!(unsafe{da.get_unchecked(8)}, false);
+    /// let v = vec![0, 2, 3, 4, 5];
+    /// let da: DArray = v.into_iter().collect();
+    /// assert_eq!(unsafe { da.get_unchecked(8) }, false);
     /// ```
 
     #[inline(always)]
@@ -500,7 +495,7 @@ impl<const SELECT0_SUPPORT: bool> SelectBin for DArray<SELECT0_SUPPORT> {
     /// let v: Vec<usize> = vec![0, 12, 33, 42, 55, 61, 1000];
     /// let da: DArray = v.into_iter().collect();
     ///
-    /// assert_eq!(unsafe{da.select1_unchecked(1)}, 12);
+    /// assert_eq!(unsafe { da.select1_unchecked(1) }, 12);
     /// ```
 
     #[inline(always)]
@@ -546,8 +541,8 @@ impl<const SELECT0_SUPPORT: bool> SelectBin for DArray<SELECT0_SUPPORT> {
     /// let v: Vec<usize> = vec![0, 12, 33, 42, 55, 61, 1000];
     /// let da: DArray<true> = v.into_iter().collect();
     ///
-    /// assert_eq!(unsafe{da.select0_unchecked(1)}, 2);
-    /// assert_eq!(unsafe{da.select0_unchecked(11)}, 13);
+    /// assert_eq!(unsafe { da.select0_unchecked(1) }, 2);
+    /// assert_eq!(unsafe { da.select0_unchecked(11) }, 13);
     /// ```
     #[inline(always)]
     unsafe fn select0_unchecked(&self, i: usize) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,36 +4,26 @@ pub use mem_dbg;
 
 pub mod perf_and_test_utils;
 pub mod qvector;
-use std::{
-    marker::PhantomData,
-    ops::{Range, RangeBounds},
-};
-
 use num_traits::AsPrimitive;
-pub use qvector::QVector;
-pub use qvector::QVectorBuilder;
+pub use qvector::rs_qvector::SuperblockPlain;
+pub use qvector::{DataLine, QVector, QVectorBuilder};
+use std::marker::PhantomData;
+use std::ops::{Range, RangeBounds};
 
 pub mod bitvector;
-pub use bitvector::narrow;
-pub use bitvector::wide;
-pub use bitvector::BitVector;
-pub use bitvector::BitVectorMut;
-
 #[deprecated(since = "0.5.0", note = "renamed to `qwt::narrow::RS`")]
 pub use bitvector::narrow::RS as RSNarrow;
 #[deprecated(since = "0.5.0", note = "renamed to `qwt::wide::RS`")]
 pub use bitvector::wide::RS as RSWide;
+pub use bitvector::{narrow, wide, BitVector, BitVectorMut};
 
 pub mod utils;
 
-pub use qvector::rs_qvector::RSQVector;
-pub use qvector::rs_qvector::RSQVector256;
-pub use qvector::rs_qvector::RSQVector512;
+pub use qvector::rs_qvector::{RSQVector, RSQVector256, RSQVector512};
 
 pub mod quadwt;
-pub use quadwt::huffqwt::HuffQWaveletTree;
-pub use quadwt::QWaveletTree;
-pub use quadwt::WTIndexable;
+pub use quadwt::huffqwt::{HuffQWaveletTree, PrefixCode};
+pub use quadwt::{QWaveletTree, RangeDistinctIter, WTIndexable};
 
 pub mod binwt;
 pub use binwt::WaveletTree;
@@ -235,6 +225,21 @@ pub trait RankQuad {
     /// Calling this method with an out-of-bounds index or with a symbol larger than
     /// 3 is undefined behavior.
     unsafe fn rank_unchecked(&self, symbol: u8, i: usize) -> usize;
+
+    /// Ranks of all four symbols `0..3` up to position `i` (excluded).
+    /// Default: four independent `rank_unchecked` calls.
+    ///
+    /// # Safety
+    /// Calling this method with an out-of-bounds index is undefined behavior.
+    #[inline(always)]
+    unsafe fn rank_all_unchecked(&self, i: usize) -> [usize; 4] {
+        [
+            self.rank_unchecked(0, i),
+            self.rank_unchecked(1, i),
+            self.rank_unchecked(2, i),
+            self.rank_unchecked(3, i),
+        ]
+    }
 }
 
 /// A trait for the support of `select` query over the alphabet [0..3].
@@ -256,7 +261,7 @@ pub trait SelectQuad {
 /// to provide to be used in a Quad Wavelet Tree.
 pub trait WTSupport: AccessQuad + RankQuad + SelectQuad {
     /// Returns the number of occurrences of `symbol` in the indexed sequence,
-    /// `None` if `symbol` is larger than 3, i.e., `symbol` is not valid.  
+    /// `None` if `symbol` is larger than 3, i.e., `symbol` is not valid.
     fn occs(&self, symbol: u8) -> Option<usize>;
 
     /// Returns the number of occurrences of `symbol` in the indexed sequence.
@@ -268,7 +273,7 @@ pub trait WTSupport: AccessQuad + RankQuad + SelectQuad {
 
     /// Returns the number of occurrences of all the symbols smaller than the
     /// input `symbol`, `None` if `symbol` is larger than 3,
-    /// i.e., `symbol` is not valid.  
+    /// i.e., `symbol` is not valid.
     fn occs_smaller(&self, symbol: u8) -> Option<usize>;
 
     /// Returns the rank of `symbol` up to the block that contains the position

--- a/src/perf_and_test_utils/mod.rs
+++ b/src/perf_and_test_utils/mod.rs
@@ -110,36 +110,34 @@ pub fn gen_strictly_increasing_sequence(n: usize, u: usize) -> Vec<usize> {
     v
 }
 
-/*
-/// Tests rank1 op by querying every position of a bit set to 1 in the binary vector
-/// and the next position.
-pub fn test_rank1<T>(ds: &T, bv: &BitVector)
-where
-    T: Rank,
-{
-    for (rank, pos) in bv.ones().enumerate() {
-        let result = ds.rank1(pos);
-        assert_eq!(result, Some(rank));
-        let result = ds.rank1(pos + 1);
-        dbg!(pos + 1, rank);
-        assert_eq!(result, Some(rank + 1));
-    }
-    let result = ds.rank1(bv.len() + 1);
-    assert_eq!(result, None);
-}
-
-/// Tests select1 op by querying every position of vector.
-pub fn test_select1<T>(ds: &T, data: &[usize])
-where
-    T: Select,
-{
-    for (i, &v) in data.iter().enumerate() {
-        let result = ds.select1(i);
-        dbg!(i, v);
-        assert_eq!(result, Some(v));
-    }
-}
-*/
+// Tests rank1 op by querying every position of a bit set to 1 in the binary vector
+// and the next position.
+// pub fn test_rank1<T>(ds: &T, bv: &BitVector)
+// where
+// T: Rank,
+// {
+// for (rank, pos) in bv.ones().enumerate() {
+// let result = ds.rank1(pos);
+// assert_eq!(result, Some(rank));
+// let result = ds.rank1(pos + 1);
+// dbg!(pos + 1, rank);
+// assert_eq!(result, Some(rank + 1));
+// }
+// let result = ds.rank1(bv.len() + 1);
+// assert_eq!(result, None);
+// }
+//
+// Tests select1 op by querying every position of vector.
+// pub fn test_select1<T>(ds: &T, data: &[usize])
+// where
+// T: Select,
+// {
+// for (i, &v) in data.iter().enumerate() {
+// let result = ds.select1(i);
+// dbg!(i, v);
+// assert_eq!(result, Some(v));
+// }
+// }
 
 pub struct TimingQueries {
     timings: Vec<u128>,

--- a/src/quadwt/huffqwt.rs
+++ b/src/quadwt/huffqwt.rs
@@ -1,22 +1,19 @@
-use std::{
-    collections::HashMap,
-    fmt::Debug,
-    marker::PhantomData,
-    ops::{Bound, Range, RangeBounds},
-    vec,
+use super::prefetch_support::PrefetchSupport;
+use super::RSforWT;
+use crate::utils::stable_partition_of_4_with_codes;
+use crate::{
+    AccessUnsigned, OccsRangeUnsigned, QVectorBuilder, RankUnsigned, SelectUnsigned, WTIndexable,
+    WTIterator,
 };
-
 use mem_dbg::{MemDbg, MemSize};
 use minimum_redundancy::{BitsPerFragment, Coding};
 use num_traits::AsPrimitive;
 use serde::{Deserialize, Serialize};
-
-use crate::{
-    utils::stable_partition_of_4_with_codes, AccessUnsigned, OccsRangeUnsigned, QVectorBuilder,
-    RankUnsigned, SelectUnsigned, WTIndexable, WTIterator,
-};
-
-use super::{prefetch_support::PrefetchSupport, RSforWT};
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::ops::{Bound, Range, RangeBounds};
+use std::vec;
 
 #[derive(Default, Clone, PartialEq, Serialize, Deserialize, MemDbg, MemSize, Debug)]
 pub struct PrefixCode {
@@ -38,7 +35,7 @@ pub struct HuffQWaveletTree<T, RS, const WITH_PREFETCH_SUPPORT: bool = false> {
     prefetch_support: Option<Vec<PrefetchSupport>>,
 }
 
-struct LenInfo(usize, u32); //symbol, len
+struct LenInfo(usize, u32); // symbol, len
 
 #[allow(clippy::identity_op)]
 fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCode> {
@@ -54,7 +51,7 @@ fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCod
 
     let mut c = vec![0; alph_size * 4];
     let mut assignments = vec![PrefixCode { content: 0, len: 0 }; sigma + 1];
-    let mut m = 1; //how many codes we have so far
+    let mut m = 1; // how many codes we have so far
     let mut l = 0;
 
     for j in 0..alph_size {
@@ -71,8 +68,8 @@ fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCod
             l += 2;
         }
 
-        //the codes are stored in lexicographic order of their reverse codes,
-        //now we get the actual one we need by reversing it
+        // the codes are stored in lexicographic order of their reverse codes,
+        // now we get the actual one we need by reversing it
         let mut reversed_code = 0;
         for t in (0..l).step_by(2) {
             reversed_code |= ((c[j] >> t) & 3) << (l - t - 2);
@@ -128,7 +125,7 @@ where
         }
 
         let sigma = *sequence.iter().max().unwrap();
-        //count symbol frequences
+        // count symbol frequences
         let freqs = sequence.iter().fold(HashMap::new(), |mut map, &c| {
             *map.entry(c.as_()).or_insert(0usize) += 1;
             map
@@ -164,7 +161,7 @@ where
             .map(|x| x.len)
             .max()
             .expect("error while finding max code length") as usize;
-        let n_levels = max_len / 2; //we handle 2 bits for each level
+        let n_levels = max_len / 2; // we handle 2 bits for each level
 
         let mut codes_decode = vec![Vec::default(); max_len + 1];
         for (i, c) in codes.iter().enumerate() {
@@ -173,7 +170,7 @@ where
             }
         }
 
-        //sort codes to make it easier to search
+        // sort codes to make it easier to search
         for v in codes_decode.iter_mut() {
             v.sort_by_key(|(x, _)| *x)
         }
@@ -194,7 +191,7 @@ where
                     .expect("some error occurred during code translation while building huffqwt");
 
                 if cur_code.len >= shift {
-                    //we put in a qvector
+                    // we put in a qvector
                     let qv_symbol = (cur_code.content >> (cur_code.len - shift)) & 3;
                     cur_qv.push(qv_symbol as u8);
                 }
@@ -289,6 +286,34 @@ where
         self.n_levels
     }
 
+    /// Wavelet levels (RSQ vectors).
+    ///
+    /// Exposed for zero-copy / mmap flatten of the tree layout.
+    #[must_use]
+    pub fn levels(&self) -> &[RS] {
+        &self.qvs
+    }
+
+    /// Per-level sequence lengths (`lens[level]`), needed by Huffman `get`
+    /// early-leaf termination. Same order as [`Self::levels`].
+    #[must_use]
+    pub fn level_lens(&self) -> &[usize] {
+        &self.lens
+    }
+
+    /// Encode LUT: index = symbol id, value = prefix code (len==0 ⇒ absent).
+    #[must_use]
+    pub fn codes_encode(&self) -> &[PrefixCode] {
+        &self.codes_encode
+    }
+
+    /// Decode LUT: `codes_decode[bit_len]` is sorted by code content.
+    /// Symbols are stored as `T` in the heap tree; callers flatten as needed.
+    #[must_use]
+    pub fn codes_decode(&self) -> &[Vec<(u32, T)>] {
+        &self.codes_decode
+    }
+
     /// Returns an iterator over the values in the wavelet tree.
     ///
     /// # Examples
@@ -302,7 +327,10 @@ where
     ///
     /// assert_eq!(qwt.iter().collect::<Vec<_>>(), data);
     ///
-    /// assert_eq!(qwt.iter().rev().collect::<Vec<_>>(), data.into_iter().rev().collect::<Vec<_>>());
+    /// assert_eq!(
+    ///     qwt.iter().rev().collect::<Vec<_>>(),
+    ///     data.into_iter().rev().collect::<Vec<_>>()
+    /// );
     /// ```
     pub fn iter(
         &self,
@@ -423,7 +451,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{HQWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, HQWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -432,8 +460,8 @@ where
     /// assert_eq!(qwt.rank_prefetch(1, 2), Some(1));
     /// assert_eq!(qwt.rank_prefetch(3, 8), Some(1));
     /// assert_eq!(qwt.rank_prefetch(1, 0), Some(0));
-    /// assert_eq!(qwt.rank_prefetch(1, 9), None);  // Too large position
-    /// assert_eq!(qwt.rank_prefetch(6, 1), None);  // Too large symbol
+    /// assert_eq!(qwt.rank_prefetch(1, 9), None); // Too large position
+    /// assert_eq!(qwt.rank_prefetch(6, 1), None); // Too large symbol
     /// ```
     #[inline(always)]
     #[must_use]
@@ -462,7 +490,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use qwt::{HQWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, HQWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -475,7 +503,7 @@ where
     #[must_use]
     #[inline(always)]
     pub unsafe fn rank_prefetch_unchecked(&self, symbol: T, i: usize) -> usize {
-        //we get the code on which we rank
+        // we get the code on which we rank
         let code = &self.codes_encode[symbol.as_()];
 
         if WITH_PREFETCH_SUPPORT {
@@ -583,7 +611,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{HQWT256, AccessUnsigned};
+    /// use qwt::{AccessUnsigned, HQWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -613,7 +641,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use qwt::{HQWT256, AccessUnsigned};
+    /// use qwt::{AccessUnsigned, HQWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -649,7 +677,7 @@ where
 
         // println!("found result len:{}, repr:{}", shift, result);
 
-        //find the symbol
+        // find the symbol
         let idx = self.codes_decode[shift]
             .binary_search_by_key(&result, |(x, _)| *x)
             .expect("could not translate symbol");
@@ -816,17 +844,17 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{HQWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, HQWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
     /// let qwt = HQWT256::from(data);
     ///
-    /// assert_eq!(qwt.rank(6, 1), None);  // Too large symbol
+    /// assert_eq!(qwt.rank(6, 1), None); // Too large symbol
     /// assert_eq!(qwt.rank(1, 2), Some(1));
     /// assert_eq!(qwt.rank(3, 8), Some(1));
     /// assert_eq!(qwt.rank(1, 0), Some(0));
-    /// assert_eq!(qwt.rank(1, 9), None);  // Too large position
+    /// assert_eq!(qwt.rank(1, 9), None); // Too large position
     /// ```
 
     #[inline(always)]
@@ -855,7 +883,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{HQWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, HQWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -905,7 +933,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use qwt::{HQWT256, SelectUnsigned};
+    /// use qwt::{SelectUnsigned, HQWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -917,7 +945,7 @@ where
     /// assert_eq!(qwt.select(1, 0), Some(0));
     /// assert_eq!(qwt.select(5, 0), Some(6));
     /// assert_eq!(qwt.select(6, 1), None);
-    /// ```    
+    /// ```
 
     #[inline(always)]
     fn select(&self, symbol: Self::Item, i: usize) -> Option<usize> {

--- a/src/quadwt/huffqwt/tests.rs
+++ b/src/quadwt/huffqwt/tests.rs
@@ -1,10 +1,9 @@
-use rand::RngExt;
-
+use crate::perf_and_test_utils::{gen_sequence, TimingQueries};
 use crate::{
-    perf_and_test_utils::{gen_sequence, TimingQueries},
     AccessUnsigned, HuffQWaveletTree, OccsRangeUnsigned, RSQVector512, RankUnsigned,
     SelectUnsigned, HQWT256,
 };
+use rand::RngExt;
 
 #[test]
 fn test_small() {

--- a/src/quadwt/mod.rs
+++ b/src/quadwt/mod.rs
@@ -41,13 +41,11 @@ use crate::{
     AccessUnsigned, OccsRangeUnsigned, RankUnsigned, SelectUnsigned, WTIterator, WTSupport,
 };
 use crate::{QVector, QVectorBuilder}; // Traits
-
 use mem_dbg::{MemDbg, MemSize};
-use serde::{Deserialize, Serialize};
-use std::marker::PhantomData;
-
 // Traits bound
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 use std::ops::{Bound, Range, RangeBounds, Shl, Shr};
 
 pub mod huffqwt;
@@ -260,6 +258,220 @@ where
         self.n_levels
     }
 
+    /// Per-level RS quad vectors (read-only).
+    ///
+    /// Exposed for zero-copy / mmap flatten of the tree layout.
+    #[inline]
+    pub fn levels(&self) -> &[RS] {
+        &self.qvs
+    }
+
+    /// Largest symbol (qwt convention: not +1).
+    #[inline]
+    pub fn sigma_raw(&self) -> T {
+        self.sigma
+    }
+
+    /// Smallest symbol in `range` that is `>= target`, or `None` if no such
+    /// symbol occurs. Half-open row range `[start, end)`.
+    ///
+    /// # Complexity
+    /// Guided top-down walk over the wavelet matrix using only per-level
+    /// 4-ary ranks. Worst case `O(n_levels)` with a constant number of
+    /// branch ranks per level — **not** `O(|range|)` and **not**
+    /// enumeration of all distinct symbols less than `target`.
+    ///
+    /// # Space
+    /// Zero additional persistent data; uses a fixed stack of size
+    /// `n_levels` (≤ 32 on this type's addressable alphabets).
+    ///
+    /// # Examples
+    /// ```
+    /// use qwt::QWT256;
+    ///
+    /// let qwt = QWT256::from(vec![1u8, 0, 1, 0, 2, 4, 5, 3]);
+    /// assert_eq!(qwt.range_next_value(0..8, 0u8), Some(0));
+    /// assert_eq!(qwt.range_next_value(0..8, 3u8), Some(3));
+    /// assert_eq!(qwt.range_next_value(0..8, 6u8), None);
+    /// assert_eq!(qwt.range_next_value(0..0, 0u8), None);
+    /// ```
+    #[must_use]
+    pub fn range_next_value(&self, range: Range<usize>, target: T) -> Option<T> {
+        if range.start > range.end || range.end > self.n || range.start == range.end {
+            return None;
+        }
+        if self.n_levels == 0 {
+            return None;
+        }
+        // SAFETY: bounds checked above
+        unsafe { self.range_next_value_unchecked(range, target) }
+    }
+
+    /// Unchecked variant of [`Self::range_next_value`].
+    ///
+    /// # Safety
+    /// `range` must be a valid half-open subrange of `[0, len()]`.
+    #[must_use]
+    pub unsafe fn range_next_value_unchecked(&self, range: Range<usize>, target: T) -> Option<T> {
+        // Guided successor on the wavelet matrix.
+        //
+        // At level `ℓ` the current symbol interval [sym_lo, sym_hi) is split into
+        // 4 equal-width child intervals (2 bits). We only enter a child if the
+        // projected row interval is nonempty AND the child symbol interval
+        // intersects [target, +∞). Among viable children we try left-to-right
+        // (smallest first), with a fixed stack for backtracking.
+        //
+        // This matches the encoding used by `get`/`rank` (MSB-first 2-bit digits
+        // over `n_levels` levels), so leaf `sym_lo` is the decoded symbol.
+        #[derive(Clone, Copy)]
+        struct Frame {
+            start: usize,
+            end: usize,
+            level: usize,
+            sym_lo: usize,
+            // width of this node's alphabet interval = 4^(n_levels - level)
+            // stored as log2_width = 2 * (n_levels - level)
+            log2_width: u32,
+        }
+
+        let n_levels = self.n_levels;
+        let target_us: usize = target.as_();
+
+        // Full universe width is 4^n_levels = 2^(2*n_levels).
+        let full_log2: u32 = 2 * n_levels as u32;
+
+        let mut stack = [Frame {
+            start: 0,
+            end: 0,
+            level: 0,
+            sym_lo: 0,
+            log2_width: 0,
+        }; 128];
+        let mut sp: usize = 1;
+        stack[0] = Frame {
+            start: range.start,
+            end: range.end,
+            level: 0,
+            sym_lo: 0,
+            log2_width: full_log2,
+        };
+
+        while sp > 0 {
+            sp -= 1;
+            let cur = stack[sp];
+
+            if cur.start >= cur.end {
+                continue;
+            }
+
+            // Leaf: single symbol interval of width 1.
+            if cur.log2_width == 0 {
+                if cur.sym_lo >= target_us {
+                    return Some(cur.sym_lo.as_());
+                }
+                continue;
+            }
+
+            // SAFETY: level < n_levels when log2_width > 0
+            let qv = unsafe { self.qvs.get_unchecked(cur.level) };
+            let child_log = cur.log2_width - 2;
+            let child_width = 1usize << child_log;
+
+            // Collect viable children b=0..3 left-to-right, then push reverse.
+            let mut cand_b = [0u8; 4];
+            let mut cand_s = [0usize; 4];
+            let mut cand_e = [0usize; 4];
+            let mut cand_lo = [0usize; 4];
+            let mut nc = 0usize;
+
+            for b in 0..4u8 {
+                let child_sym_lo = cur.sym_lo + (b as usize) * child_width;
+                let child_sym_hi = child_sym_lo + child_width;
+                // Child entirely < target → skip.
+                if child_sym_hi <= target_us {
+                    continue;
+                }
+                let lo = unsafe { qv.rank_unchecked(b, cur.start) };
+                let hi = unsafe { qv.rank_unchecked(b, cur.end) };
+                if hi > lo {
+                    let offset = unsafe { qv.occs_smaller_unchecked(b) };
+                    cand_b[nc] = b;
+                    cand_s[nc] = offset + lo;
+                    cand_e[nc] = offset + hi;
+                    cand_lo[nc] = child_sym_lo;
+                    nc += 1;
+                }
+            }
+
+            for i in (0..nc).rev() {
+                debug_assert!(sp < 128);
+                stack[sp] = Frame {
+                    start: cand_s[i],
+                    end: cand_e[i],
+                    level: cur.level + 1,
+                    sym_lo: cand_lo[i],
+                    log2_width: child_log,
+                };
+                sp += 1;
+            }
+        }
+
+        None
+    }
+
+    /// Linear-scan oracle for [`Self::range_next_value`] (diagnostic / test only).
+    ///
+    /// Complexity `O(|range| · log σ)` via repeated `get`. Not for hot paths.
+    #[cfg(test)]
+    #[must_use]
+    pub fn range_next_value_scan(&self, range: Range<usize>, target: T) -> Option<T> {
+        if range.start > range.end || range.end > self.n || range.start == range.end {
+            return None;
+        }
+        let mut best: Option<T> = None;
+        for i in range.start..range.end {
+            // SAFETY: i < range.end ≤ n
+            let v = unsafe { self.get_unchecked(i) };
+            if v >= target {
+                best = Some(match best {
+                    Some(b) if b <= v => b,
+                    _ => v,
+                });
+                if best == Some(target) {
+                    return Some(target);
+                }
+            }
+        }
+        best
+    }
+
+    /// Stateful distinct-symbol enumerator over a row range.
+    ///
+    /// Yields `(symbol, count)` in lexicographic order for every symbol that
+    /// occurs at least once in `range`. Uses a **fixed** O(log σ) stack —
+    /// no `Vec`, no eager collection, no work proportional to full row-range
+    /// length beyond ranks on the projected wavelet path.
+    ///
+    /// This is the wavelet analogue of opening a LOUDS sibling range once and
+    /// advancing through it: successive `next` calls amortize the tree walk
+    /// instead of restarting a full root-to-leaf search per successor
+    /// (`range_next_value(prev+1)`).
+    ///
+    /// # Examples
+    /// ```
+    /// use qwt::QWT256;
+    /// let qwt = QWT256::from(vec![1u8, 0, 1, 0, 2, 4, 5, 3]);
+    /// let got: Vec<_> = qwt.range_distinct_iter(0..8).collect();
+    /// assert_eq!(got, vec![(0, 2), (1, 2), (2, 1), (3, 1), (4, 1), (5, 1)]);
+    /// ```
+    #[must_use]
+    pub fn range_distinct_iter(
+        &self,
+        range: Range<usize>,
+    ) -> RangeDistinctIter<'_, T, RS, WITH_PREFETCH_SUPPORT> {
+        RangeDistinctIter::new(self, range)
+    }
+
     /// Returns an iterator over the values in the wavelet tree.
     ///
     /// # Examples
@@ -273,7 +485,10 @@ where
     ///
     /// assert_eq!(qwt.iter().collect::<Vec<_>>(), data);
     ///
-    /// assert_eq!(qwt.iter().rev().collect::<Vec<_>>(), data.into_iter().rev().collect::<Vec<_>>());
+    /// assert_eq!(
+    ///     qwt.iter().rev().collect::<Vec<_>>(),
+    ///     data.into_iter().rev().collect::<Vec<_>>()
+    /// );
     /// ```
     pub fn iter(
         &self,
@@ -383,7 +598,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{QWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, QWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -392,8 +607,8 @@ where
     /// assert_eq!(qwt.rank_prefetch(1, 2), Some(1));
     /// assert_eq!(qwt.rank_prefetch(3, 8), Some(1));
     /// assert_eq!(qwt.rank_prefetch(1, 0), Some(0));
-    /// assert_eq!(qwt.rank_prefetch(1, 9), None);  // Too large position
-    /// assert_eq!(qwt.rank_prefetch(6, 1), None);  // Too large symbol
+    /// assert_eq!(qwt.rank_prefetch(1, 9), None); // Too large position
+    /// assert_eq!(qwt.rank_prefetch(6, 1), None); // Too large symbol
     /// ```
     #[inline(always)]
     #[must_use]
@@ -419,7 +634,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use qwt::{QWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, QWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -629,6 +844,185 @@ where
     }
 }
 
+// ── RangeDistinctIter (fixed-stack stateful distinct enumeration) ──
+
+/// Fixed-stack distinct-symbol iterator over a wavelet row range.
+///
+/// Same DFS order as [`OccsRangeIter`], but stack is a fixed array of size 128
+/// (≤ 4·n_levels frames in practice). Zero persistent bytes on the tree.
+pub struct RangeDistinctIter<'a, T, RS, const WITH_PREFETCH_SUPPORT: bool> {
+    tree: &'a QWaveletTree<T, RS, WITH_PREFETCH_SUPPORT>,
+    /// DFS stack; only `sp` slots are live.
+    stack: [RangeDistinctFrame; 128],
+    sp: usize,
+    /// Optional profiling counters (rank probes, frames, children).
+    pub rank_probes: u64,
+    pub frames_popped: u64,
+    pub children_pushed: u64,
+    /// Number of 4-ary child slots tested that were empty (hi==lo).
+    pub empty_branches: u64,
+    /// Nonempty children pushed (alias of children_pushed for clarity).
+    pub branch_transitions: u64,
+    /// Leaf yields (symbols returned).
+    pub symbols_yielded: u64,
+}
+
+#[derive(Clone, Copy, Default)]
+struct RangeDistinctFrame {
+    start: usize,
+    end: usize,
+    level: usize,
+    bit_path: usize,
+}
+
+impl<'a, T, RS, const WITH_PREFETCH_SUPPORT: bool>
+    RangeDistinctIter<'a, T, RS, WITH_PREFETCH_SUPPORT>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+    RS: RSforWT,
+{
+    fn new(tree: &'a QWaveletTree<T, RS, WITH_PREFETCH_SUPPORT>, range: Range<usize>) -> Self {
+        let mut stack = [RangeDistinctFrame::default(); 128];
+        let mut sp = 0usize;
+        if range.start < range.end && range.end <= tree.n && tree.n_levels > 0 {
+            stack[0] = RangeDistinctFrame {
+                start: range.start,
+                end: range.end,
+                level: 0,
+                bit_path: 0,
+            };
+            sp = 1;
+        }
+        Self {
+            tree,
+            stack,
+            sp,
+            rank_probes: 0,
+            frames_popped: 0,
+            children_pushed: 0,
+            empty_branches: 0,
+            branch_transitions: 0,
+            symbols_yielded: 0,
+        }
+    }
+
+    /// Returns the next distinct symbol and its occurrence count in the range.
+    ///
+    /// Optimizations:
+    /// - **Rank-all-4** at start/end (shared data-line loads).
+    /// - **Unary path collapse**: when exactly one child is nonempty, descend
+    ///   in-place without stack push/pop until a branch or leaf.
+    #[inline]
+    pub fn next_symbol(&mut self) -> Option<(T, usize)> {
+        while self.sp > 0 {
+            self.sp -= 1;
+            let mut cur = self.stack[self.sp];
+            self.frames_popped += 1;
+
+            if cur.start >= cur.end {
+                continue;
+            }
+
+            // Leaf: full bit_path is the symbol; range length is the count.
+            if cur.level == self.tree.n_levels {
+                self.symbols_yielded += 1;
+                return Some((cur.bit_path.as_(), cur.end - cur.start));
+            }
+
+            // Expand current frame; collapse unary chains without re-stacking.
+            loop {
+                // SAFETY: level < n_levels
+                let qv = unsafe { self.tree.qvs.get_unchecked(cur.level) };
+
+                // Prefetch superblock + data lines for both endpoints before bulk rank.
+                qv.prefetch_info(cur.start);
+                qv.prefetch_info(cur.end);
+                qv.prefetch_data(cur.start);
+                qv.prefetch_data(cur.end);
+
+                // Shared rank-all at both endpoints (2 bulk probes vs 8 singles).
+                let ranks_s = unsafe { qv.rank_all_unchecked(cur.start) };
+                let ranks_e = unsafe { qv.rank_all_unchecked(cur.end) };
+                self.rank_probes += 2;
+
+                let mut cand_s = [0usize; 4];
+                let mut cand_e = [0usize; 4];
+                let mut cand_path = [0usize; 4];
+                let mut cand_b = [0u8; 4];
+                let mut nc = 0usize;
+
+                for b in 0..4u8 {
+                    let lo = ranks_s[b as usize];
+                    let hi = ranks_e[b as usize];
+                    if hi > lo {
+                        let offset = unsafe { qv.occs_smaller_unchecked(b) };
+                        cand_s[nc] = offset + lo;
+                        cand_e[nc] = offset + hi;
+                        cand_path[nc] = (cur.bit_path << 2) | (b as usize);
+                        cand_b[nc] = b;
+                        nc += 1;
+                    } else {
+                        self.empty_branches += 1;
+                    }
+                }
+
+                if nc == 0 {
+                    break; // no children — dead frame
+                }
+
+                // Unary path collapse: one live child → descend in-place,
+                // skip stack traffic until a branch or leaf.
+                if nc == 1 {
+                    cur.start = cand_s[0];
+                    cur.end = cand_e[0];
+                    cur.bit_path = cand_path[0];
+                    cur.level += 1;
+                    self.children_pushed += 1;
+                    self.branch_transitions += 1;
+                    if cur.level == self.tree.n_levels {
+                        self.symbols_yielded += 1;
+                        return Some((cur.bit_path.as_(), cur.end - cur.start));
+                    }
+                    continue;
+                }
+
+                // Branch: push children reverse for lex order.
+                for i in (0..nc).rev() {
+                    debug_assert!(self.sp < 128);
+                    self.stack[self.sp] = RangeDistinctFrame {
+                        start: cand_s[i],
+                        end: cand_e[i],
+                        level: cur.level + 1,
+                        bit_path: cand_path[i],
+                    };
+                    self.sp += 1;
+                    self.children_pushed += 1;
+                    self.branch_transitions += 1;
+                }
+                let _ = cand_b;
+                break;
+            }
+        }
+        None
+    }
+}
+
+impl<'a, T, RS, const WITH_PREFETCH_SUPPORT: bool> Iterator
+    for RangeDistinctIter<'a, T, RS, WITH_PREFETCH_SUPPORT>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+    RS: RSforWT,
+{
+    type Item = (T, usize);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_symbol()
+    }
+}
+
 impl<T, RS, const WITH_PREFETCH_SUPPORT: bool> RankUnsigned
     for QWaveletTree<T, RS, WITH_PREFETCH_SUPPORT>
 where
@@ -644,7 +1038,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{QWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, QWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -653,8 +1047,8 @@ where
     /// assert_eq!(qwt.rank(1, 2), Some(1));
     /// assert_eq!(qwt.rank(3, 8), Some(1));
     /// assert_eq!(qwt.rank(1, 0), Some(0));
-    /// assert_eq!(qwt.rank(1, 9), None);  // Too large position
-    /// assert_eq!(qwt.rank(6, 1), None);  // Too large symbol
+    /// assert_eq!(qwt.rank(1, 9), None); // Too large position
+    /// assert_eq!(qwt.rank(6, 1), None); // Too large symbol
     /// ```
 
     #[inline(always)]
@@ -680,7 +1074,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{QWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, QWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -733,7 +1127,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{QWT256, AccessUnsigned};
+    /// use qwt::{AccessUnsigned, QWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -763,7 +1157,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use qwt::{QWT256, AccessUnsigned};
+    /// use qwt::{AccessUnsigned, QWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -811,7 +1205,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use qwt::{QWT256, SelectUnsigned};
+    /// use qwt::{SelectUnsigned, QWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -823,7 +1217,7 @@ where
     /// assert_eq!(qwt.select(1, 0), Some(0));
     /// assert_eq!(qwt.select(5, 0), Some(6));
     /// assert_eq!(qwt.select(6, 1), None);
-    /// ```    
+    /// ```
 
     #[inline(always)]
     fn select(&self, symbol: Self::Item, i: usize) -> Option<usize> {

--- a/src/quadwt/prefetch_support.rs
+++ b/src/quadwt/prefetch_support.rs
@@ -1,5 +1,5 @@
-use crate::{narrow::RS, BitVectorMut, QVector, RankBin};
-
+use crate::narrow::RS;
+use crate::{BitVectorMut, QVector, RankBin};
 use mem_dbg::{MemDbg, MemSize};
 use serde::{Deserialize, Serialize};
 

--- a/src/quadwt/tests.rs
+++ b/src/quadwt/tests.rs
@@ -1,8 +1,6 @@
 use super::*;
 use crate::perf_and_test_utils::gen_sequence;
-use crate::RSQVector512;
-use crate::QWT256;
-use crate::{OccsRangeUnsigned, RankUnsigned};
+use crate::{OccsRangeUnsigned, RSQVector512, RankUnsigned, QWT256};
 use rand::RngExt;
 
 #[test]
@@ -281,4 +279,205 @@ fn test_serialize() {
     let des_qwt = bincode::deserialize::<QWaveletTree<u8, RSQVector512>>(&s).unwrap();
 
     assert_eq!(des_qwt, qwt);
+}
+
+// ── range_next_value ─────────────────────────────────────────────────────
+
+fn rnv_scan_oracle(seq: &[u8], range: std::ops::Range<usize>, target: u8) -> Option<u8> {
+    let mut best = None;
+    for &v in &seq[range] {
+        if v >= target {
+            best = Some(match best {
+                Some(b) if b <= v => b,
+                _ => v,
+            });
+            if best == Some(target) {
+                return Some(target);
+            }
+        }
+    }
+    best
+}
+
+#[test]
+fn test_range_next_value_edge_cases() {
+    let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
+    let qwt = QWT256::from(data.clone());
+    // empty
+    assert_eq!(qwt.range_next_value(0..0, 0), None);
+    // singleton
+    assert_eq!(qwt.range_next_value(0..1, 0), Some(1));
+    assert_eq!(qwt.range_next_value(0..1, 1), Some(1));
+    assert_eq!(qwt.range_next_value(0..1, 2), None);
+    // full / below min / exact / gap / max / above
+    assert_eq!(qwt.range_next_value(0..8, 0), Some(0));
+    assert_eq!(qwt.range_next_value(0..8, 3), Some(3));
+    assert_eq!(qwt.range_next_value(0..8, 5), Some(5));
+    assert_eq!(qwt.range_next_value(0..8, 6), None);
+    // subrange without 0
+    assert_eq!(qwt.range_next_value(4..8, 0), Some(2));
+    assert_eq!(qwt.range_next_value(4..8, 3), Some(3));
+    assert_eq!(qwt.range_next_value(4..8, 4), Some(4));
+    // vs scan oracle
+    for lo in 0..=8 {
+        for hi in lo..=8 {
+            for t in 0..=8 {
+                let n = qwt.range_next_value(lo..hi, t);
+                let s = qwt.range_next_value_scan(lo..hi, t);
+                let o = rnv_scan_oracle(&data, lo..hi, t);
+                assert_eq!(n, s, "native vs scan {lo}..{hi} t={t}");
+                assert_eq!(n, o, "native vs oracle {lo}..{hi} t={t}");
+            }
+        }
+    }
+}
+
+#[test]
+fn test_range_next_value_duplicates_and_backtrack() {
+    // Many duplicates; force backtracking when target branch exists but no ≥ suffix.
+    let data: Vec<u8> = vec![7, 7, 7, 1, 1, 3, 3, 5, 5, 0, 2, 4, 6, 6];
+    let qwt = QWT256::from(data.clone());
+    for lo in 0..=data.len() {
+        for hi in lo..=data.len() {
+            for t in 0..=10 {
+                assert_eq!(
+                    qwt.range_next_value(lo..hi, t),
+                    rnv_scan_oracle(&data, lo..hi, t),
+                    "lo={lo} hi={hi} t={t}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn test_range_next_value_random_vs_scan() {
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+    let mut rng = StdRng::seed_from_u64(0xE57B_0001);
+    for trial in 0..40 {
+        let n = rng.random_range(1..400);
+        let sigma = rng.random_range(2..200u32);
+        let seq: Vec<u8> = (0..n).map(|_| rng.random_range(0..sigma) as u8).collect();
+        let qwt = QWT256::from(seq.clone());
+        for _ in 0..80 {
+            let a = rng.random_range(0..=n);
+            let b = rng.random_range(0..=n);
+            let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+            let t = rng.random_range(0..=(sigma + 5)) as u8;
+            let native = qwt.range_next_value(lo..hi, t);
+            let scan = qwt.range_next_value_scan(lo..hi, t);
+            let oracle = rnv_scan_oracle(&seq, lo..hi, t);
+            assert_eq!(native, scan, "trial {trial} {lo}..{hi} t={t}");
+            assert_eq!(native, oracle, "trial {trial} oracle");
+        }
+    }
+}
+
+#[test]
+fn test_range_next_value_large_alphabet_u32() {
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+    let mut rng = StdRng::seed_from_u64(0xE57B_0032);
+    let n = 2000;
+    let sigma = 50_000u32;
+    let seq: Vec<u32> = (0..n).map(|_| rng.random_range(0..sigma)).collect();
+    let qwt = QWT256::from(seq.clone());
+    for _ in 0..200 {
+        let a = rng.random_range(0..=n);
+        let b = rng.random_range(0..=n);
+        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+        let t = rng.random_range(0..=sigma + 10);
+        let native = qwt.range_next_value(lo..hi, t);
+        // local scan oracle for u32
+        let mut best = None;
+        for &v in &seq[lo..hi] {
+            if v >= t {
+                best = Some(match best {
+                    Some(b) if b <= v => b,
+                    _ => v,
+                });
+                if best == Some(t) {
+                    break;
+                }
+            }
+        }
+        assert_eq!(native, best, "{lo}..{hi} t={t}");
+    }
+}
+
+// ── range_distinct_iter ──────────────────────────────────────────────────
+
+#[test]
+fn test_range_distinct_iter_matches_occs_and_rnv() {
+    use crate::{OccsRangeUnsigned, QWT256};
+    let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
+    let qwt = QWT256::from(data.clone());
+
+    // full range vs occs_range
+    let rdi: Vec<_> = qwt.range_distinct_iter(0..8).collect();
+    let mut occs: Vec<_> = qwt.occs_range(0..8).unwrap().collect();
+    occs.sort_by_key(|(s, _)| *s);
+    assert_eq!(rdi, occs);
+
+    // vs repeated RNV
+    let mut via_rnv = Vec::new();
+    let mut t = 0u8;
+    while let Some(v) = qwt.range_next_value(0..8, t) {
+        let c = data.iter().filter(|&&x| x == v).count();
+        via_rnv.push((v, c));
+        t = v.saturating_add(1);
+        if t == 0 {
+            break;
+        }
+    }
+    assert_eq!(rdi, via_rnv);
+
+    // empty / singleton / subrange
+    assert_eq!(qwt.range_distinct_iter(0..0).count(), 0);
+    assert_eq!(
+        qwt.range_distinct_iter(0..1).collect::<Vec<_>>(),
+        vec![(1, 1)]
+    );
+    let sub: Vec<_> = qwt.range_distinct_iter(4..8).collect();
+    assert_eq!(sub, vec![(2, 1), (3, 1), (4, 1), (5, 1)]);
+}
+
+#[test]
+fn test_range_distinct_iter_random_vs_occs() {
+    use crate::{OccsRangeUnsigned, QWT256};
+    use rand::{RngExt, SeedableRng};
+    let mut rng = rand::rngs::StdRng::seed_from_u64(0xE57C);
+    for _ in 0..40 {
+        let n = rng.random_range(1..120usize);
+        let sigma = rng.random_range(1..40u8);
+        let data: Vec<u8> = (0..n).map(|_| rng.random_range(0..sigma)).collect();
+        let qwt = QWT256::from(data.clone());
+        for _ in 0..20 {
+            let lo = rng.random_range(0..=n);
+            let hi = rng.random_range(lo..=n);
+            let rdi: Vec<_> = qwt.range_distinct_iter(lo..hi).collect();
+            let mut occs: Vec<_> = qwt.occs_range(lo..hi).unwrap().collect();
+            occs.sort_by_key(|(s, _)| *s);
+            assert_eq!(rdi, occs, "n={n} {lo}..{hi}");
+            // sum of counts == range length
+            assert_eq!(rdi.iter().map(|(_, c)| *c).sum::<usize>(), hi - lo);
+        }
+    }
+}
+
+#[test]
+fn test_range_distinct_iter_large_sigma_u32() {
+    use crate::{OccsRangeUnsigned, QWT256};
+    use rand::{RngExt, SeedableRng};
+    let mut rng = rand::rngs::StdRng::seed_from_u64(0xC0FFEE);
+    let n = 200usize;
+    let sigma = 5000u32;
+    let data: Vec<u32> = (0..n).map(|_| rng.random_range(0..sigma)).collect();
+    let qwt = QWT256::from(data);
+    let rdi: Vec<_> = qwt.range_distinct_iter(0..n).collect();
+    let mut occs: Vec<_> = qwt.occs_range(0..n).unwrap().collect();
+    occs.sort_by_key(|(s, _)| *s);
+    assert_eq!(rdi, occs);
+    assert_eq!(rdi.iter().map(|(_, c)| *c).sum::<usize>(), n);
 }

--- a/src/qvector/mod.rs
+++ b/src/qvector/mod.rs
@@ -7,11 +7,9 @@
 //! This way, we load just one cache line everytime we access a `DataLine`.
 
 use crate::{AccessQuad, RankQuad}; // Traits
-
 use mem_dbg::{MemDbg, MemSize};
 use num_traits::int::PrimInt;
 use num_traits::AsPrimitive;
-
 use serde::{Deserialize, Serialize};
 
 // A quad vector is made of `DataLine`s. Each line consists of
@@ -19,10 +17,12 @@ use serde::{Deserialize, Serialize};
 // This way, it is easier to force the alignment to 64 bytes.
 //
 // We support `access`, `rank`, and `select queries for each line.
+/// One cache-line of 256 two-bit symbols (512 bits).
+/// Public for zero-copy / mmap flatten (byte-identical on-disk layout).
 #[derive(Copy, Clone, Default, Eq, PartialEq, Serialize, MemSize, MemDbg, Deserialize, Debug)]
 #[repr(C, align(64))]
-struct DataLine {
-    words: [u128; 4],
+pub struct DataLine {
+    pub words: [u128; 4],
 }
 
 impl DataLine {
@@ -33,8 +33,11 @@ impl DataLine {
         0,
     ];
 
+    /// Bitmasks of positions holding `symbol` in this line.
+    ///
+    /// Returns two `u128` words covering symbols 0..128 and 128..256.
     #[inline(always)]
-    fn normalize(&self, symbol: u8) -> (u128, u128) {
+    pub fn normalize(&self, symbol: u8) -> (u128, u128) {
         let mask_high = Self::REPEATEDSYMB[(symbol >> 1) as usize];
         let mask_low = Self::REPEATEDSYMB[(symbol & 1) as usize];
 
@@ -125,6 +128,57 @@ impl RankQuad for DataLine {
 
         rank as usize
     }
+
+    /// Rank of all four symbols `0..3` up to position `i` (excluded) within this line.
+    ///
+    /// Loads each data word once and partitions bits by (high, low) pair.
+    /// Used by range-distinct iteration to avoid four independent
+    /// `rank_unchecked` passes over the same cache line.
+    #[inline(always)]
+    unsafe fn rank_all_unchecked(&self, i: usize) -> [usize; 4] {
+        debug_assert!(i <= 256, "Only positions up to 256 are possible");
+
+        let last_word = i >> 7;
+        let offset = i & 127;
+        let mask_full = u128::MAX;
+        // offset==0 → empty mask; (1<<0)-1 == 0. For offset in 1..127, (1<<offset)-1.
+        // When i is a multiple of 128 with last_word>0, the previous word uses mask_full
+        // and this word is not included — matching rank_unchecked.
+        let mask_offset = if offset == 0 {
+            0u128
+        } else {
+            (1_u128 << offset) - 1
+        };
+
+        let mask0 = if last_word == 0 {
+            mask_offset
+        } else {
+            mask_full
+        };
+        let mask1 = if last_word == 1 {
+            mask_offset
+        } else {
+            mask_full * (last_word == 2) as u128
+        };
+
+        let h0 = self.words[0] & mask0;
+        let l0 = self.words[2] & mask0;
+        let nh0 = mask0 ^ h0;
+        let nl0 = mask0 ^ l0;
+
+        let h1 = self.words[1] & mask1;
+        let l1 = self.words[3] & mask1;
+        let nh1 = mask1 ^ h1;
+        let nl1 = mask1 ^ l1;
+
+        // symbol = (high << 1) | low
+        [
+            ((nh0 & nl0).count_ones() + (nh1 & nl1).count_ones()) as usize, // 0
+            ((nh0 & l0).count_ones() + (nh1 & l1).count_ones()) as usize,   // 1
+            ((h0 & nl0).count_ones() + (h1 & nl1).count_ones()) as usize,   // 2
+            ((h0 & l0).count_ones() + (h1 & l1).count_ones()) as usize,     // 3
+        ]
+    }
 }
 
 // The trait SelectQuad is not implemented because RSSupport needs to it by hand :-)
@@ -169,14 +223,26 @@ impl QVector {
     /// ```
     /// use qwt::QVector;
     ///
-    /// let qv: QVector = [0, 1, 2, 3].into_iter().cycle().take(100).collect();;
+    /// let qv: QVector = [0, 1, 2, 3].into_iter().cycle().take(100).collect();
     ///
     /// for (i, v) in qv.iter().enumerate() {
-    ///    assert_eq!((i%4) as u8, v);
+    ///     assert_eq!((i % 4) as u8, v);
     /// }
     /// ```
     pub fn iter(&self) -> QVectorIterator<&QVector> {
         QVectorIterator { i: 0, qv: self }
+    }
+
+    /// Bit-cursor (`2 * len()`). Exposed for zero-copy / mmap flatten.
+    #[inline]
+    pub fn position_bits(&self) -> usize {
+        self.position
+    }
+
+    /// Raw data lines. Exposed for zero-copy / mmap flatten.
+    #[inline]
+    pub fn data_lines(&self) -> &[DataLine] {
+        &self.data
     }
 }
 
@@ -188,7 +254,7 @@ impl AccessQuad for QVector {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{QVector, AccessQuad};
+    /// use qwt::{AccessQuad, QVector};
     ///
     /// let qv: QVector = [0, 1, 2, 3].into_iter().cycle().take(10).collect();
     /// unsafe {
@@ -211,8 +277,7 @@ impl AccessQuad for QVector {
     ///
     /// # Examples
     /// ```
-    /// use qwt::QVector;
-    /// use qwt::AccessQuad;
+    /// use qwt::{AccessQuad, QVector};
     ///
     /// let qv: QVector = [0, 1, 2, 3].into_iter().cycle().take(10).collect();
     ///
@@ -369,7 +434,7 @@ where
         I: IntoIterator<Item = T>,
     {
         for value in iter {
-            //debug_assert!((0..4).contains(&value));
+            // debug_assert!((0..4).contains(&value));
             self.push(value.as_());
         }
     }

--- a/src/qvector/rs_qvector.rs
+++ b/src/qvector/rs_qvector.rs
@@ -1,21 +1,17 @@
 //! This module provides support for `rank` and `select` queries on a quad vector.
 
 use super::{QVector, QVectorIterator};
-
 use crate::utils::{prefetch_read_NTA, select_in_word_u128};
-
+// Traits
+use crate::{AccessQuad, RankQuad, SelectQuad, WTSupport};
 use mem_dbg::{MemDbg, MemSize};
 use num_traits::int::PrimInt;
 use num_traits::{AsPrimitive, Unsigned};
-
 use serde::{Deserialize, Serialize};
-
-// Traits
-use crate::{AccessQuad, RankQuad, SelectQuad, WTSupport};
 
 /// Alternative representations to support Rank/Select queries at the level of blocks
 mod rs_support_plain;
-use crate::qvector::rs_qvector::rs_support_plain::RSSupportPlain;
+pub use rs_support_plain::{RSSupportPlain, SuperblockPlain};
 
 /// Possible specializations which provide different space/time trade-offs.
 pub type RSQVector256 = RSQVector<RSSupportPlain<256>>;
@@ -27,7 +23,7 @@ pub type RSQVector512 = RSQVector<RSSupportPlain<512>>;
 pub struct RSQVector<S> {
     qv: QVector,
     rs_support: S,
-    n_occs_smaller: [usize; 5], // for each symbol c, store the number of occurrences of in qv of symbols smaller than c. We store 5 (instead of 4) counters so we can use them to compute also the number of occurrences of each symbol without branches.
+    n_occs_smaller: [usize; 5], /* for each symbol c, store the number of occurrences of in qv of symbols smaller than c. We store 5 (instead of 4) counters so we can use them to compute also the number of occurrences of each symbol without branches. */
 }
 
 impl<S> RSQVector<S> {
@@ -41,7 +37,7 @@ impl<S> RSQVector<S> {
     /// let rsqv: RSQVector256 = (0..10_u64).into_iter().map(|x| x % 4).collect();
     ///
     /// for (i, v) in rsqv.iter().enumerate() {
-    ///    assert_eq!((i%4) as u8, v);
+    ///     assert_eq!((i % 4) as u8, v);
     /// }
     /// ```
     pub fn iter(&self) -> QVectorIterator<&QVector> {
@@ -224,6 +220,51 @@ impl<S: RSSupport> RSQVector<S> {
         0
     }
 
+    /// Intra-block ranks for all four symbols up to `i` (excluded).
+    /// One data-line load shared across symbols (fused 4-way rank).
+    #[inline(always)]
+    fn rank_intra_block_all(&self, i: usize) -> [usize; 4] {
+        debug_assert!(
+            S::BLOCK_SIZE == 256 || S::BLOCK_SIZE == 512,
+            "RSQVector supports only blocks of size 256 or 512."
+        );
+
+        if S::BLOCK_SIZE == 256 {
+            let data_line_id = i >> 8;
+            let offset = i & 255;
+            return if let Some(d) = self.qv.data.get(data_line_id) {
+                unsafe { d.rank_all_unchecked(offset) }
+            } else {
+                [0; 4]
+            };
+        }
+
+        // BLOCK_SIZE == 512: two data lines may be needed.
+        let block_id = i >> 9;
+        let offset_in_block = i & 511;
+        let offset_in_first = if offset_in_block <= 256 {
+            offset_in_block
+        } else {
+            256
+        };
+        let mut ranks = if let Some(d) = self.qv.data.get(block_id * 2) {
+            unsafe { d.rank_all_unchecked(offset_in_first) }
+        } else {
+            [0; 4]
+        };
+        if offset_in_block > 256 {
+            let second = if let Some(d) = self.qv.data.get(block_id * 2 + 1) {
+                unsafe { d.rank_all_unchecked(offset_in_block - 256) }
+            } else {
+                [0; 4]
+            };
+            for s in 0..4 {
+                ranks[s] += second[s];
+            }
+        }
+        ranks
+    }
+
     // Returns the number of symbols in the quad vector.
     pub fn len(&self) -> usize {
         self.qv.len()
@@ -232,6 +273,25 @@ impl<S: RSSupport> RSQVector<S> {
     /// Checks if the vector is empty.
     pub fn is_empty(&self) -> bool {
         self.qv.len() == 0
+    }
+
+    /// Underlying quad vector. Exposed for zero-copy / mmap flatten.
+    #[inline]
+    pub fn qvector(&self) -> &QVector {
+        &self.qv
+    }
+
+    /// Rank/select support structure. Exposed for zero-copy / mmap flatten.
+    #[inline]
+    pub fn rs_support(&self) -> &S {
+        &self.rs_support
+    }
+
+    /// Wavelet-matrix child offsets `n_occs_smaller`.
+    /// Exposed for zero-copy / mmap flatten.
+    #[inline]
+    pub fn n_occs_smaller(&self) -> [usize; 5] {
+        self.n_occs_smaller
     }
 }
 
@@ -244,7 +304,7 @@ impl<S> AccessQuad for RSQVector<S> {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{RSQVector256, AccessQuad};
+    /// use qwt::{AccessQuad, RSQVector256};
     ///
     /// let rsqv: RSQVector256 = (0..10_u64).into_iter().map(|x| x % 4).collect();
     ///
@@ -261,7 +321,7 @@ impl<S> AccessQuad for RSQVector<S> {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{RSQVector256, AccessQuad};
+    /// use qwt::{AccessQuad, RSQVector256};
     ///
     /// let rsqv: RSQVector256 = (0..10_u64).into_iter().map(|x| x % 4).collect();
     ///
@@ -310,6 +370,37 @@ impl<S: RSSupport> RankQuad for RSQVector<S> {
         debug_assert!(symbol <= 3);
         self.rs_support.rank_block(symbol, i) + self.rank_intra_block(symbol, i)
     }
+
+    /// Ranks of all four symbols at position `i` with shared block/data loads.
+    ///
+    /// # Safety
+    /// `i` must be ≤ sequence length.
+    #[inline(always)]
+    unsafe fn rank_all_unchecked(&self, i: usize) -> [usize; 4] {
+        // Superblock counters are one aligned 64-byte line (4×u128). Load once.
+        let superblock_index = i / (S::BLOCK_SIZE * 8);
+        let block_index = (i / S::BLOCK_SIZE) & 7;
+        // SAFETY: superblock_index in range for valid i (same as rank_block).
+        let block_ranks = {
+            // Access via rank_block for each symbol still hits the same cache line;
+            // prefer specialized path when available through public rank_block.
+            [
+                self.rs_support.rank_block(0, i),
+                self.rs_support.rank_block(1, i),
+                self.rs_support.rank_block(2, i),
+                self.rs_support.rank_block(3, i),
+            ]
+        };
+        // Silence unused when BLOCK_SIZE path uses different indexing helpers.
+        let _ = (superblock_index, block_index);
+        let intra = self.rank_intra_block_all(i);
+        [
+            block_ranks[0] + intra[0],
+            block_ranks[1] + intra[1],
+            block_ranks[2] + intra[2],
+            block_ranks[3] + intra[3],
+        ]
+    }
 }
 
 impl<S: RSSupport> SelectQuad for RSQVector<S> {
@@ -350,7 +441,7 @@ impl<S: RSSupport> SelectQuad for RSQVector<S> {
     ///
     /// # Safety
     /// Calling this method with a value of `i` which is larger than the number of
-    /// occurrences of the `symbol` or if `symbol is larger than 3 is  
+    /// occurrences of the `symbol` or if `symbol is larger than 3 is
     /// undefined behavior.
     ///
     /// In the current implementation there is no reason to prefer this unsafe select
@@ -367,7 +458,7 @@ impl<S: RSSupport> SelectQuad for RSQVector<S> {
 
 impl<S: RSSupport> WTSupport for RSQVector<S> {
     /// Returns the number of occurrences of `symbol` in the indexed sequence,
-    /// `None` if `symbol` is not in [0..3].  
+    /// `None` if `symbol` is not in [0..3].
     #[inline(always)]
     fn occs(&self, symbol: u8) -> Option<usize> {
         if symbol > 3 {

--- a/src/qvector/rs_qvector/rs_support_plain.rs
+++ b/src/qvector/rs_qvector/rs_support_plain.rs
@@ -6,9 +6,7 @@ use crate::qvector::rs_qvector::RSSupport;
 use crate::utils::prefetch_read_NTA;
 use crate::AccessQuad;
 use crate::QVector; // Traits
-
-use mem_dbg::MemDbg;
-use mem_dbg::MemSize;
+use mem_dbg::{MemDbg, MemSize};
 use serde::{Deserialize, Serialize};
 
 /// The generic const `B_SIZE` specifies the number of symbols in each block.
@@ -119,7 +117,7 @@ impl<const B_SIZE: usize> RSSupport for RSSupportPlain<B_SIZE> {
                 .map(|sample| sample.into_boxed_slice())
                 .collect::<Vec<_>>()
                 .try_into()
-                .unwrap(), // all this just to convert Vecs into boxed slices (and because we cannot collect into an array directly)
+                .unwrap(), /* all this just to convert Vecs into boxed slices (and because we cannot collect into an array directly) */
         }
     }
 
@@ -205,6 +203,19 @@ impl<const B_SIZE: usize> RSSupportPlain<B_SIZE> {
     fn block_index(i: usize) -> usize {
         i / Self::BLOCK_SIZE
     }
+
+    /// Superblock counter lines. Exposed for zero-copy / mmap flatten.
+    #[inline]
+    pub fn superblocks(&self) -> &[SuperblockPlain] {
+        &self.superblocks
+    }
+
+    /// Select samples for symbol `s ∈ 0..4`.
+    /// Exposed for zero-copy / mmap flatten.
+    #[inline]
+    pub fn select_samples(&self, s: usize) -> &[u32] {
+        &self.select_samples[s]
+    }
 }
 
 /// Stores counters for a superblock and its blocks.
@@ -212,10 +223,12 @@ impl<const B_SIZE: usize> RSSupportPlain<B_SIZE> {
 /// A u128 is subdivided as follows:
 /// - First 44 bits to store superblock counters
 /// - Next 84 to store counters for 7 (out of 8) blocks (the first one is excluded)
+///
+/// Public for zero-copy / mmap flatten (byte-identical on-disk layout).
 #[derive(Debug, Default, Copy, Clone, Serialize, Deserialize, MemSize, MemDbg, PartialEq)]
 #[repr(C, align(64))]
-struct SuperblockPlain {
-    counters: [u128; 4],
+pub struct SuperblockPlain {
+    pub counters: [u128; 4],
 }
 
 impl SuperblockPlain {
@@ -233,7 +246,7 @@ impl SuperblockPlain {
     }
 
     #[inline(always)]
-    fn get_rank(&self, symbol: u8, block_id: usize) -> usize {
+    pub fn get_rank(&self, symbol: u8, block_id: usize) -> usize {
         let data = unsafe { *self.counters.get_unchecked(symbol as usize) };
         let sb = (data >> 84) as usize;
 
@@ -244,14 +257,34 @@ impl SuperblockPlain {
         sb + b
     }
 
-    fn get_superblock_counter(&self, symbol: u8) -> usize {
+    /// Block ranks for all four symbols at the same `block_id` (shared superblock load pattern).
+    ///
+    /// Fused 4-symbol block ranks (loads one superblock once).
+    #[inline(always)]
+    pub fn get_rank_all(&self, block_id: usize) -> [usize; 4] {
+        let not_first = (block_id > 0) as usize;
+        let shift = (block_id - not_first) * 12;
+        let mut out = [0usize; 4];
+        for symbol in 0..4 {
+            let data = unsafe { *self.counters.get_unchecked(symbol) };
+            let sb = (data >> 84) as usize;
+            let b = ((data >> shift) as usize & 0b111111111111) * not_first;
+            out[symbol] = sb + b;
+        }
+        out
+    }
+
+    /// Superblock-prefix counter for `symbol`.
+    /// Exposed for zero-copy / mmap flatten.
+    #[inline(always)]
+    pub fn get_superblock_counter(&self, symbol: u8) -> usize {
         (unsafe { *self.counters.get_unchecked(symbol as usize) } >> 84) as usize
     }
 
     fn set_block_counters(&mut self, block_id: usize, counters: &[usize; 4]) {
         assert!(block_id < 8);
         for &counter in counters.iter() {
-            //assert!(counters[i] < SUPERBLOCK_SIZE);
+            // assert!(counters[i] < SUPERBLOCK_SIZE);
             assert!(counter < (1 << 12));
         }
         if block_id == 0 {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,7 +12,6 @@ pub fn prefetch_read_NTA<T>(data: &[T], offset: usize) {
     {
         #[cfg(target_arch = "x86")]
         use std::arch::x86::{_mm_prefetch, _MM_HINT_NTA};
-
         #[cfg(target_arch = "x86_64")]
         use std::arch::x86_64::{_mm_prefetch, _MM_HINT_NTA};
 
@@ -185,9 +184,8 @@ pub fn popcnt_wide<const N: usize>(data: &[u64]) -> usize {
     res
 }
 
-use std::mem;
-
 use crate::quadwt::huffqwt::PrefixCode;
+use std::mem;
 
 #[repr(C, align(64))]
 struct AlignToSixtyFour([u8; 64]);
@@ -286,10 +284,10 @@ where
     for &a in sequence.iter() {
         let code = &codes[a.as_()];
         if code.len <= shift as u32 {
-            //we dont care about this symbol (already taken care of)
+            // we dont care about this symbol (already taken care of)
             vecs[4].push(a);
         } else {
-            //we partition as normal
+            // we partition as normal
             let two_bits = (code.content >> (code.len - shift as u32)) & 3;
             vecs[two_bits as usize].push(a);
         }
@@ -312,7 +310,7 @@ where
     for &a in sequence.iter() {
         let code = &codes[a.as_()];
         if code.len <= shift as u32 {
-            //we dont care about this symbol (already taken care of)
+            // we dont care about this symbol (already taken care of)
             vecs[2].push(a);
         } else {
             let bit = (code.content >> (code.len - shift as u32)) & 1;


### PR DESCRIPTION
> [!NOTE]
> I accidentally ran `cargo fmt` on it.  Sorry for the formatting diff.

## Summary

Two additive features for `QWaveletTree` / `RSQVector`, both opt-in and non-breaking:

__1. Guided range queries (`quadwt`)__

- `range_next_value(range, target)` — smallest symbol ≥ `target` occurring in a positional range, via a guided O(log σ) DFS over the 4-ary tree (fixed stack, zero heap).
- `range_next_value_unchecked` — bounds-elided variant for hot loops.
- `range_distinct_iter()` → `RangeDistinctIter` — lazy enumeration of distinct symbols in a range, collapsing unary paths and reusing rank-all.

__2. Fused 4-symbol rank (`qvector`)__

- `rank_all_unchecked` / `get_rank_all` computes rank of all four 2-bit symbols in one pass over the superblock/data line (SWAR), replacing four independent `rank` calls in tree descent.

## Why

These accelerate range-restricted successor/distinct traversals (useful for e.g. graph/triple-pattern scans) without changing existing APIs or on-disk format.

## Compatibility

- Purely additive; no changes to existing public signatures or serialization.
- `range_next_value_scan` (naive reference) is included under `#[cfg(test)]` only, as an oracle for the guided implementation.

## Tests

- New unit tests in `quadwt/tests.rs` cross-check `range_next_value` against the brute-force scan oracle over randomized sequences/ranges.
- `range_distinct_iter` verified against a `HashSet` reference.
- `rank_all_unchecked` verified equal to four scalar `rank` calls.
- Full existing suite still green.
