### PR TITLE
Fix unchecked rank access for invalid RSQVector symbols

### DIFF
--- a/src/qvector/rs_qvector.rs
+++ b/src/qvector/rs_qvector.rs
@@ -277,7 +277,7 @@ impl<S> AccessQuad for RSQVector<S> {
 
 impl<S: RSSupport> RankQuad for RSQVector<S> {
     /// Returns rank of `symbol` up to position `i` **excluded**.
-    /// Returns `None` if out of bounds.
+    /// Returns `None` if `i` is out of bounds or `symbol` is not in [0..3].
     ///
     /// # Examples
     /// ```
@@ -293,10 +293,10 @@ impl<S: RSSupport> RankQuad for RSQVector<S> {
     /// ```
     #[inline(always)]
     fn rank(&self, symbol: u8, i: usize) -> Option<usize> {
-        if i > self.qv.len() {
+        if symbol > 3 || i > self.qv.len() {
             return None;
         }
-        // Safety: The check above guarantees we are not out of bound
+        // Safety: The checks above guarantee a valid symbol and position.
         Some(unsafe { self.rank_unchecked(symbol, i) })
     }
 
@@ -514,6 +514,18 @@ mod tests {
         assert_eq!(rsqv.rank(1, 256), Some(0));
         assert_eq!(rsqv.rank(2, 256), Some(0));
         assert_eq!(rsqv.rank(3, 256), Some(0));
+    }
+
+    #[test]
+    fn test_rank_rejects_invalid_symbols<D>()
+    where
+        D: From<QVector> + RankQuad,
+    {
+        let qv: QVector = [0, 1, 2, 3].into_iter().collect();
+        let rsqv = D::from(qv);
+
+        assert_eq!(rsqv.rank(4, 0), None);
+        assert_eq!(rsqv.rank(u8::MAX, 4), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject symbols outside the quaternary alphabet in the safe `RSQVector::rank` API
- document the invalid-symbol behavior
- add regression coverage for both RSQVector256 and RSQVector512

## Why

`RSQVector::rank` previously validated only the position before calling `rank_unchecked`. A symbol greater than 3 could therefore reach unchecked counter indexing through a safe public API.

## Testing

- `cargo fmt --check`
- `cargo test` (82 unit tests and 116 documentation tests passed)