### PR TITLE
Validate QVector invariants during deserialization

### DIFF
--- a/src/qvector/mod.rs
+++ b/src/qvector/mod.rs
@@ -12,7 +12,7 @@ use mem_dbg::{MemDbg, MemSize};
 use num_traits::int::PrimInt;
 use num_traits::AsPrimitive;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 // A quad vector is made of `DataLine`s. Each line consists of
 // four u128, so each `DataLine` is 512 bits and fits in a cache line.
@@ -129,10 +129,44 @@ impl RankQuad for DataLine {
 
 // The trait SelectQuad is not implemented because RSSupport needs to it by hand :-)
 
-#[derive(Clone, Default, Eq, PartialEq, Serialize, MemSize, MemDbg, Deserialize, Debug)]
+#[derive(Clone, Default, Eq, PartialEq, Serialize, MemSize, MemDbg, Debug)]
 pub struct QVector {
     data: Box<[DataLine]>,
     position: usize,
+}
+
+impl<'de> Deserialize<'de> for QVector {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct QVectorWire {
+            data: Box<[DataLine]>,
+            position: usize,
+        }
+
+        let wire = QVectorWire::deserialize(deserializer)?;
+        let capacity = wire
+            .data
+            .len()
+            .checked_mul(512)
+            .ok_or_else(|| serde::de::Error::custom("QVector data capacity overflow"))?;
+        if !wire.position.is_multiple_of(2) {
+            return Err(serde::de::Error::custom(
+                "QVector position must be a multiple of 2",
+            ));
+        }
+        if wire.position > capacity {
+            return Err(serde::de::Error::custom(
+                "QVector position exceeds data capacity",
+            ));
+        }
+        Ok(Self {
+            data: wire.data,
+            position: wire.position,
+        })
+    }
 }
 
 impl QVector {

--- a/src/qvector/rs_qvector.rs
+++ b/src/qvector/rs_qvector.rs
@@ -8,7 +8,7 @@ use mem_dbg::{MemDbg, MemSize};
 use num_traits::int::PrimInt;
 use num_traits::{AsPrimitive, Unsigned};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 // Traits
 use crate::{AccessQuad, RankQuad, SelectQuad, WTSupport};
@@ -23,11 +23,32 @@ pub type RSQVector512 = RSQVector<RSSupportPlain<512>>;
 
 /// The generic `S` is the data structure used to provide rank/select
 /// support at the level of blocks.
-#[derive(Default, Clone, PartialEq, Debug, Serialize, MemSize, MemDbg, Deserialize)]
+#[derive(Default, Clone, PartialEq, Debug, Serialize, MemSize, MemDbg)]
 pub struct RSQVector<S> {
     qv: QVector,
     rs_support: S,
     n_occs_smaller: [usize; 5], // for each symbol c, store the number of occurrences of in qv of symbols smaller than c. We store 5 (instead of 4) counters so we can use them to compute also the number of occurrences of each symbol without branches.
+}
+
+impl<'de, S> Deserialize<'de> for RSQVector<S>
+where
+    S: Deserialize<'de> + RSSupport,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RSQVectorWire<S> {
+            qv: QVector,
+            rs_support: S,
+            n_occs_smaller: [usize; 5],
+        }
+
+        let wire = RSQVectorWire::<S>::deserialize(deserializer)?;
+        let _ = (wire.rs_support, wire.n_occs_smaller);
+        Ok(Self::from(wire.qv))
+    }
 }
 
 impl<S> RSQVector<S> {

--- a/src/qvector/tests.rs
+++ b/src/qvector/tests.rs
@@ -1,6 +1,22 @@
 use super::*;
 
 #[test]
+fn deserialize_rejects_position_beyond_data_capacity() {
+    #[derive(Serialize)]
+    struct QVectorWire {
+        data: Box<[DataLine]>,
+        position: usize,
+    }
+
+    let bytes = bincode::serialize(&QVectorWire {
+        data: Box::new([]),
+        position: 2,
+    })
+    .unwrap();
+    assert!(bincode::deserialize::<QVector>(&bytes).is_err());
+}
+
+#[test]
 fn test_empty() {
     let qv = QVector::default();
     assert!(qv.is_empty());


### PR DESCRIPTION
## Summary

- replace derived QVector deserialization with validation of the bit cursor and backing data capacity
- rebuild RSQVector's derived rank/select support and occurrence counters after deserialization instead of trusting serialized caches
- add a regression for an empty backing array with a nonzero logical length

## Security impact

A crafted bincode/Serde cache could previously set QVector's logical length beyond its backing allocation. Safe get calls trusted that length and reached an unchecked data-line access.

## Tests

- cargo test --all-features --offline qvector
- 24 qvector tests passed