### PR TITLE
Reuse partition buffers during QWT construction

### DIFF
--- a/src/quadwt/huffqwt.rs
+++ b/src/quadwt/huffqwt.rs
@@ -12,8 +12,8 @@ use num_traits::AsPrimitive;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    utils::stable_partition_of_4_with_codes, AccessUnsigned, OccsRangeUnsigned, QVectorBuilder,
-    RankUnsigned, SelectUnsigned, WTIndexable, WTIterator,
+    utils::stable_partition_of_4_with_codes_into, AccessUnsigned, OccsRangeUnsigned,
+    QVectorBuilder, RankUnsigned, SelectUnsigned, WTIndexable, WTIterator,
 };
 
 use super::{prefetch_support::PrefetchSupport, RSforWT};
@@ -114,6 +114,18 @@ where
     /// assert_eq!(qwt.len(), 8);
     /// ```
     pub fn new(sequence: &mut [T]) -> Self {
+        let mut partitioned = vec![T::zero(); sequence.len()];
+        Self::from_buffers(sequence, &mut partitioned)
+    }
+
+    /// Builds from an owned sequence using one reusable partition buffer.
+    fn from_owned(mut sequence: Vec<T>) -> Self {
+        let mut partitioned = vec![T::zero(); sequence.len()];
+        Self::from_buffers(&mut sequence, &mut partitioned)
+    }
+
+    /// Builds the index by alternating between the input and scratch buffers.
+    fn from_buffers<'a>(mut sequence: &'a mut [T], mut partitioned: &'a mut [T]) -> Self {
         if sequence.is_empty() {
             return Self {
                 n: 0,
@@ -187,6 +199,7 @@ where
 
         for _level in 0..n_levels {
             let mut cur_qv = QVectorBuilder::new();
+            let mut counts = [0usize; 5];
 
             for &s in sequence.iter() {
                 let cur_code = codes
@@ -198,6 +211,12 @@ where
                     let qv_symbol = (cur_code.content >> (cur_code.len - shift)) & 3;
                     cur_qv.push(qv_symbol as u8);
                 }
+                let bucket = if cur_code.len <= shift {
+                    4
+                } else {
+                    ((cur_code.content >> (cur_code.len - shift)) & 3) as usize
+                };
+                counts[bucket] += 1;
             }
 
             let qv = cur_qv.build();
@@ -212,7 +231,14 @@ where
             lens.push(cur_qv_len);
             qvs.push(RS::from(qv));
 
-            stable_partition_of_4_with_codes(sequence, shift as usize, &codes);
+            stable_partition_of_4_with_codes_into(
+                sequence,
+                shift as usize,
+                &codes,
+                counts,
+                partitioned,
+            );
+            std::mem::swap(&mut sequence, &mut partitioned);
             shift += 2;
         }
 
@@ -665,8 +691,8 @@ where
     usize: AsPrimitive<T>,
     RS: RSforWT,
 {
-    fn from(mut v: Vec<T>) -> Self {
-        HuffQWaveletTree::new(&mut v[..])
+    fn from(v: Vec<T>) -> Self {
+        HuffQWaveletTree::from_owned(v)
     }
 }
 
@@ -1041,7 +1067,7 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        HuffQWaveletTree::new(&mut iter.into_iter().collect::<Vec<T>>())
+        HuffQWaveletTree::from(iter.into_iter().collect::<Vec<T>>())
     }
 }
 

--- a/src/quadwt/huffqwt.rs
+++ b/src/quadwt/huffqwt.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    cmp::Reverse,
     fmt::Debug,
     marker::PhantomData,
     ops::{Bound, Range, RangeBounds},
@@ -38,19 +38,12 @@ pub struct HuffQWaveletTree<T, RS, const WITH_PREFETCH_SUPPORT: bool = false> {
     prefetch_support: Option<Vec<PrefetchSupport>>,
 }
 
-struct LenInfo(usize, u32); //symbol, len
+struct LenInfo(usize, u32, usize); // symbol, code length, frequency
 
 #[allow(clippy::identity_op)]
-fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCode> {
-    // count size of the alphabet
-    let alph_size = freq.iter().count();
-
-    let mut f = freq
-        .iter()
-        .map(|(&k, &v)| LenInfo(k, v * 2)) // each fragment is 2 bits
-        .collect::<Vec<_>>();
-
-    f.sort_by_key(|x| x.1);
+fn craft_wm_codes(mut lengths: Vec<LenInfo>, sigma: usize) -> Vec<PrefixCode> {
+    let alph_size = lengths.len();
+    lengths.sort_unstable_by_key(|x| (x.1, Reverse(x.2), x.0));
 
     let mut c = vec![0; alph_size * 4];
     let mut assignments = vec![PrefixCode { content: 0, len: 0 }; sigma + 1];
@@ -58,9 +51,7 @@ fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCod
     let mut l = 0;
 
     for j in 0..alph_size {
-        // println!("f[{}]: ({}, {})", j, f[j].0, f[j].1);
-
-        while f[j].1 > l {
+        while lengths[j].1 > l {
             for r in j..m {
                 c[(m - j) * 3 + r] = c[r];
                 c[(m - j) * 2 + r] = c[r] | 1 << l;
@@ -78,7 +69,7 @@ fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCod
             reversed_code |= ((c[j] >> t) & 3) << (l - t - 2);
         }
 
-        assignments[f[j].0] = PrefixCode {
+        assignments[lengths[j].0] = PrefixCode {
             content: reversed_code,
             len: l,
         };
@@ -139,37 +130,35 @@ where
             };
         }
 
-        let sigma = *sequence.iter().max().unwrap();
-        //count symbol frequences
-        let freqs = sequence.iter().fold(HashMap::new(), |mut map, &c| {
-            *map.entry(c.as_()).or_insert(0usize) += 1;
-            map
-        });
+        let sigma = sequence.iter().copied().max().unwrap().as_();
+        let codes = {
+            // The encode table is already indexed by the largest symbol, so
+            // dense counting avoids hashing every input value. Frequency is
+            // also the tie-breaker for equal-length codes: hotter symbols get
+            // the lexicographically earlier paths, then symbol id stabilizes
+            // the serialized representation across processes.
+            let mut frequencies = vec![0usize; sigma + 1];
+            for &symbol in sequence.iter() {
+                frequencies[symbol.as_()] += 1;
+            }
 
-        // println!("entropy: {}", Frequencies::entropy(&freqs));
+            let mut symbol_frequencies = frequencies
+                .iter()
+                .copied()
+                .enumerate()
+                .filter(|&(_, frequency)| frequency != 0)
+                .collect::<Vec<_>>();
+            symbol_frequencies.sort_unstable_by_key(|&(symbol, frequency)| (frequency, symbol));
 
-        // println!("freqs: {:?}", &freqs);
-
-        // let tot_occs = sequence.len();
-        // println!("total occurrences: {}", tot_occs);
-
-        let mut lengths =
-            Coding::from_frequencies_cloned(BitsPerFragment(2), &freqs).code_lengths();
-
-        // println!("lengths: {:?}", &lengths);
-
-        // let mut awpl = 0;
-
-        // for (&k, &v) in lengths.iter() {
-        //     // println!("{} {} {}", &k, &v, freqs[&k]);
-        //     awpl += v as usize * 2 * freqs[&k];
-        // }
-
-        // println!("awpl in bits: {}", awpl as f64 / tot_occs as f64);
-
-        let codes = craft_wm_codes(&mut lengths, sigma.as_());
-
-        // println!("{:?}", codes);
+            let (values, mut weights): (Vec<_>, Vec<_>) = symbol_frequencies.into_iter().unzip();
+            let coding =
+                Coding::from_sorted(BitsPerFragment(2), values.into_boxed_slice(), &mut weights);
+            let lengths = coding
+                .codes()
+                .map(|(symbol, code)| LenInfo(*symbol, code.len * 2, frequencies[*symbol]))
+                .collect();
+            craft_wm_codes(lengths, sigma)
+        };
 
         let max_len = codes
             .iter()

--- a/src/quadwt/huffqwt/tests.rs
+++ b/src/quadwt/huffqwt/tests.rs
@@ -272,6 +272,19 @@ fn test_serialize() {
     assert_eq!(des_qwt, qwt);
 }
 
+#[test]
+fn construction_is_deterministic_for_tied_frequencies() {
+    let sequence = (0u16..64).cycle().take(64 * 32).collect::<Vec<_>>();
+    let expected = HuffQWaveletTree::<_, RSQVector512>::from(sequence.clone());
+
+    for _ in 0..8 {
+        assert_eq!(
+            HuffQWaveletTree::<_, RSQVector512>::from(sequence.clone()),
+            expected
+        );
+    }
+}
+
 fn gen_seq(n: usize, sigma: usize) -> Vec<u64> {
     let mut rng = rand::rng();
     (0..n).map(|_| rng.random_range(0..sigma) as u64).collect()

--- a/src/quadwt/mod.rs
+++ b/src/quadwt/mod.rs
@@ -36,7 +36,7 @@
 //! assert_eq!(qwt.select(3, 0), Some(2));  // Finds the position of the 1st occurrence of symbol 3, should return Some(2)
 //! ```
 
-use crate::utils::{msb, stable_partition_of_4};
+use crate::utils::{msb, stable_partition_of_4_into};
 use crate::{
     AccessUnsigned, OccsRangeUnsigned, RankUnsigned, SelectUnsigned, WTIterator, WTSupport,
 };
@@ -127,6 +127,18 @@ where
     /// ```
     #[must_use]
     pub fn new(sequence: &mut [T]) -> Self {
+        let mut partitioned = vec![T::zero(); sequence.len()];
+        Self::from_buffers(sequence, &mut partitioned)
+    }
+
+    /// Builds from an owned sequence using one reusable partition buffer.
+    fn from_owned(mut sequence: Vec<T>) -> Self {
+        let mut partitioned = vec![T::zero(); sequence.len()];
+        Self::from_buffers(&mut sequence, &mut partitioned)
+    }
+
+    /// Builds the index by alternating between the input and scratch buffers.
+    fn from_buffers<'a>(mut sequence: &'a mut [T], mut partitioned: &'a mut [T]) -> Self {
         if sequence.is_empty() {
             return Self {
                 n: 0,
@@ -148,9 +160,11 @@ where
 
         for _level in 0..n_levels {
             let mut cur_qv = QVectorBuilder::with_capacity(sequence.len());
+            let mut counts = [0usize; 4];
             for &symbol in sequence.iter() {
                 let two_bits: u8 = ((symbol >> shift).as_() & 3) as u8; // take the last 2 bits
                 cur_qv.push(two_bits);
+                counts[two_bits as usize] += 1;
             }
 
             let qv = cur_qv.build();
@@ -161,7 +175,8 @@ where
             }
             qvs.push(RS::from(qv));
 
-            stable_partition_of_4(sequence, shift);
+            stable_partition_of_4_into(sequence, shift, counts, partitioned);
+            std::mem::swap(&mut sequence, &mut partitioned);
 
             if shift >= 2 {
                 shift -= 2;
@@ -943,7 +958,7 @@ where
     where
         I: IntoIterator<Item = T>,
     {
-        QWaveletTree::new(&mut iter.into_iter().collect::<Vec<T>>())
+        QWaveletTree::from(iter.into_iter().collect::<Vec<T>>())
     }
 }
 
@@ -954,8 +969,8 @@ where
     usize: AsPrimitive<T>,
     RS: RSforWT,
 {
-    fn from(mut v: Vec<T>) -> Self {
-        QWaveletTree::new(&mut v[..])
+    fn from(v: Vec<T>) -> Self {
+        QWaveletTree::from_owned(v)
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -276,6 +276,35 @@ where
     }
 }
 
+/// Writes the stable four-way partition of `sequence` into `output`.
+///
+/// `counts` contains the number of values in each two-bit bucket. Callers can
+/// collect these counts while building the current wavelet-tree level, avoiding
+/// a separate counting pass and independently growing bucket vectors.
+pub(crate) fn stable_partition_of_4_into<T>(
+    sequence: &[T],
+    shift: usize,
+    counts: [usize; 4],
+    output: &mut [T],
+) where
+    T: Unsigned + PrimInt + Ord + Shr<usize> + AsPrimitive<usize>,
+    usize: AsPrimitive<T>,
+{
+    debug_assert_eq!(sequence.len(), output.len());
+    debug_assert_eq!(counts.iter().sum::<usize>(), sequence.len());
+    let mut positions = [
+        0,
+        counts[0],
+        counts[0] + counts[1],
+        counts[0] + counts[1] + counts[2],
+    ];
+    for &symbol in sequence {
+        let bucket = (symbol.as_() >> shift) & 3;
+        output[positions[bucket]] = symbol;
+        positions[bucket] += 1;
+    }
+}
+
 pub fn stable_partition_of_4_with_codes<T>(sequence: &mut [T], shift: usize, codes: &[PrefixCode])
 where
     T: Unsigned + PrimInt + Ord + Shr<usize> + AsPrimitive<usize>,
@@ -299,6 +328,39 @@ where
     for i in 0..5 {
         sequence[pos..pos + vecs[i].len()].copy_from_slice(&(vecs[i][..]));
         pos += vecs[i].len()
+    }
+}
+
+/// Writes the stable Huffman four-way partition of `sequence` into `output`.
+/// The fifth bucket contains symbols whose code ended at an earlier level.
+pub(crate) fn stable_partition_of_4_with_codes_into<T>(
+    sequence: &[T],
+    shift: usize,
+    codes: &[PrefixCode],
+    counts: [usize; 5],
+    output: &mut [T],
+) where
+    T: Unsigned + PrimInt + Ord + Shr<usize> + AsPrimitive<usize>,
+    usize: AsPrimitive<T>,
+{
+    debug_assert_eq!(sequence.len(), output.len());
+    debug_assert_eq!(counts.iter().sum::<usize>(), sequence.len());
+    let mut positions = [
+        0,
+        counts[0],
+        counts[0] + counts[1],
+        counts[0] + counts[1] + counts[2],
+        counts[0] + counts[1] + counts[2] + counts[3],
+    ];
+    for &symbol in sequence {
+        let code = &codes[symbol.as_()];
+        let bucket = if code.len <= shift as u32 {
+            4
+        } else {
+            ((code.content >> (code.len - shift as u32)) & 3) as usize
+        };
+        output[positions[bucket]] = symbol;
+        positions[bucket] += 1;
     }
 }
 

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -46,3 +46,60 @@ fn test_stable_partition_of_4() {
 
     assert_eq!(vv, v);
 }
+
+#[test]
+fn stable_partition_of_4_into_matches_bucket_partition() {
+    let input = vec![0u16, 17, 2, 31, 16, 3, 18, 1, 30, 19, 4, 29];
+    let shift = 2;
+    let mut counts = [0usize; 4];
+    for &symbol in &input {
+        counts[((symbol >> shift) & 3) as usize] += 1;
+    }
+
+    let mut expected = input.clone();
+    stable_partition_of_4(&mut expected, shift);
+    let mut output = vec![0; input.len()];
+    stable_partition_of_4_into(&input, shift, counts, &mut output);
+
+    assert_eq!(output, expected);
+}
+
+#[test]
+fn stable_partition_of_4_with_codes_into_matches_bucket_partition() {
+    let codes = vec![
+        PrefixCode { content: 0, len: 2 },
+        PrefixCode { content: 1, len: 2 },
+        PrefixCode {
+            content: 0b1000,
+            len: 4,
+        },
+        PrefixCode {
+            content: 0b1100,
+            len: 4,
+        },
+        PrefixCode {
+            content: 0b010000,
+            len: 6,
+        },
+        PrefixCode { content: 0, len: 6 },
+    ];
+    let input = vec![0u8, 2, 5, 1, 4, 3, 2, 0, 5, 4, 3, 1];
+    let shift = 2;
+    let mut counts = [0usize; 5];
+    for &symbol in &input {
+        let code = &codes[symbol as usize];
+        let bucket = if code.len <= shift {
+            4
+        } else {
+            ((code.content >> (code.len - shift)) & 3) as usize
+        };
+        counts[bucket] += 1;
+    }
+
+    let mut expected = input.clone();
+    stable_partition_of_4_with_codes(&mut expected, shift as usize, &codes);
+    let mut output = vec![0; input.len()];
+    stable_partition_of_4_with_codes_into(&input, shift as usize, &codes, counts, &mut output);
+
+    assert_eq!(output, expected);
+}


### PR DESCRIPTION
## Summary

- replace the four or five independently growing partition buckets used at each QWT construction level with one exact-sized scratch buffer reused across all levels
- collect bucket counts while emitting the current QVector, avoiding a separate counting pass
- alternate the input and scratch slices after each stable partition instead of copying bucket contents back
- route owned-vector and iterator construction through the owned path while preserving the existing destructive-slice API
- replace HQWT frequency hash maps with dense counting over its already sigma-indexed encoding domain
- deterministically assign equal-length Huffman codes by descending frequency, then symbol id
- add equivalence tests for plain/Huffman stable scatter and deterministic tied-frequency construction

The new helpers remain crate-private and do not change the public API or serialized representation.

## Benchmark

Release build on macOS arm64 using a 16 MiB byte corpus with a 39-symbol remapped alphabet:

| Structure | Upstream median construction | Partition-buffer branch | Change | Upstream peak RSS | Branch peak RSS | Change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| QWT256 | 364 ms | 331 ms | -9.1% | 120.6 MiB | 96.6 MiB | -19.9% |
| HQWT256 | 557 ms | 544 ms | -2.3% | 119.6 MiB | 99.1 MiB | -17.1% |

The dense HQWT counting pass was also isolated in Nova's release construction harness over its 1.25M-triple corpus: median construction fell from 526 ms to 327 ms (-37.8%, seven fresh runs). The measured standalone peak RSS was effectively flat (~1% run noise), while retired instructions fell by 16.5%.

## Validation

- `cargo test --offline --all-features`: 83 unit tests passed
- documentation tests: 116 passed
- `cargo fmt --all -- --check`
- `git diff --check`