### PR TITLE
Avoid heap allocations in quad-wavelet select

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ use num_traits::AsPrimitive;
 pub use qvector::QVector;
 pub use qvector::QVectorBuilder;
 
+/// Maximum number of 2-bit levels needed by the widest supported integer.
+pub(crate) const MAX_QUAD_LEVELS: usize = u128::BITS as usize / 2;
+
 pub mod bitvector;
 pub use bitvector::narrow;
 pub use bitvector::wide;

--- a/src/quadwt/huffqwt.rs
+++ b/src/quadwt/huffqwt.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     utils::stable_partition_of_4_with_codes, AccessUnsigned, OccsRangeUnsigned, QVectorBuilder,
-    RankUnsigned, SelectUnsigned, WTIndexable, WTIterator,
+    RankUnsigned, SelectUnsigned, WTIndexable, WTIterator, MAX_QUAD_LEVELS,
 };
 
 use super::{prefetch_support::PrefetchSupport, RSforWT};
@@ -925,8 +925,11 @@ where
             return None;
         }
 
-        let mut path_off = Vec::with_capacity(self.n_levels);
-        let mut rank_path_off = Vec::with_capacity(self.n_levels);
+        if self.n_levels > MAX_QUAD_LEVELS {
+            return None;
+        }
+        let mut path_off = [0usize; MAX_QUAD_LEVELS];
+        let mut rank_path_off = [0usize; MAX_QUAD_LEVELS];
 
         let code = &self.codes_encode[symbol.as_()];
         let mut shift: i64 = code.len as i64 - 2;
@@ -936,14 +939,14 @@ where
 
         let mut level = 0;
         while shift >= 0 {
-            path_off.push(b);
+            path_off[level] = b;
 
             let two_bits = ((repr >> shift as usize) & 3) as u8;
 
             let rank_b = self.qvs[level].rank(two_bits, b)?;
 
             b = rank_b + unsafe { self.qvs[level].occs_smaller_unchecked(two_bits) };
-            rank_path_off.push(rank_b);
+            rank_path_off[level] = rank_b;
 
             level += 1;
             shift -= 2;

--- a/src/quadwt/mod.rs
+++ b/src/quadwt/mod.rs
@@ -39,6 +39,7 @@
 use crate::utils::{msb, stable_partition_of_4};
 use crate::{
     AccessUnsigned, OccsRangeUnsigned, RankUnsigned, SelectUnsigned, WTIterator, WTSupport,
+    MAX_QUAD_LEVELS,
 };
 use crate::{QVector, QVectorBuilder}; // Traits
 
@@ -831,14 +832,17 @@ where
             return None;
         }
 
-        let mut path_off = Vec::with_capacity(self.n_levels);
-        let mut rank_path_off = Vec::with_capacity(self.n_levels);
+        if self.n_levels > MAX_QUAD_LEVELS {
+            return None;
+        }
+        let mut path_off = [0usize; MAX_QUAD_LEVELS];
+        let mut rank_path_off = [0usize; MAX_QUAD_LEVELS];
 
         let mut b = 0;
         let mut shift: i64 = 2 * (self.n_levels - 1) as i64;
 
         for level in 0..self.n_levels {
-            path_off.push(b);
+            path_off[level] = b;
 
             let two_bits = (symbol >> shift as usize).as_() & 3;
 
@@ -848,7 +852,7 @@ where
             b = rank_b + unsafe { self.qvs[level].occs_smaller_unchecked(two_bits as u8) };
             shift -= 2;
 
-            rank_path_off.push(rank_b);
+            rank_path_off[level] = rank_b;
         }
 
         shift = 0;


### PR DESCRIPTION
## Summary

- replace the two per-query `Vec<usize>` allocations in QWT and HQWT `select` with fixed-size stack arrays
- size the arrays from the widest supported integer (`u128`: at most 64 two-bit levels)
- retain the existing checked behavior, returning `None` for malformed structures with an impossible level count

This changes neither the public API nor the serialized representation.

## Benchmark

Nine-run release microbenchmark over owned QWT/HQWT select queries:

| Structure | Upstream median | This branch | Change |
| --- | ---: | ---: | ---: |
| QWT | 675.220 ns | 647.861 ns | -4.05% |
| HQWT | 222.453 ns | 192.178 ns | -13.61% |

The gain comes from removing two allocator round trips per select.

## Validation

- `cargo test --offline --all-features`: 80 unit tests passed
- documentation tests: 116 passed
- `cargo fmt --all -- --check`
- `git diff --check`