### PR TITLE
Harden deserialization and succinct-structure invariants

### DIFF
--- a/src/binwt/mod.rs
+++ b/src/binwt/mod.rs
@@ -7,19 +7,19 @@ use std::{
 use mem_dbg::{MemDbg, MemSize};
 use minimum_redundancy::{BitsPerFragment, Coding};
 use num_traits::AsPrimitive;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{
     quadwt::huffqwt::PrefixCode,
     utils::{msb, stable_partition_of_2, stable_partition_of_2_with_codes},
-    AccessUnsigned, BinWTSupport, BitVector, BitVectorMut, OccsRangeUnsigned, RankUnsigned,
-    SelectUnsigned, WTIndexable, WTIterator,
+    AccessBin, AccessUnsigned, BinWTSupport, BitVector, BitVectorMut, OccsRangeUnsigned,
+    RankUnsigned, SelectUnsigned, WTIndexable, WTIterator,
 };
 
 pub trait BinRSforWT: From<BitVector> + BinWTSupport + MemSize + MemDbg + Default {}
 impl<T> BinRSforWT for T where T: From<BitVector> + BinWTSupport + MemSize + MemDbg + Default {}
 
-#[derive(Default, Clone, PartialEq, Serialize, Deserialize, MemSize, MemDbg, Debug)]
+#[derive(Default, Clone, PartialEq, Serialize, MemSize, MemDbg, Debug)]
 pub struct WaveletTree<T, BRS, const COMPRESSED: bool = false> {
     n: usize,                                 // The length of the represented sequence
     n_levels: usize,                          // The number of levels of the wavelet matrix
@@ -31,7 +31,47 @@ pub struct WaveletTree<T, BRS, const COMPRESSED: bool = false> {
     phantom_data: PhantomData<T>,
 }
 
-struct LenInfo(usize, u32); //symbol, len
+#[derive(Deserialize)]
+struct WaveletTreeSerde<T, BRS> {
+    n: usize,
+    n_levels: usize,
+    sigma: Option<T>,
+    codes_encode: Option<Vec<PrefixCode>>,
+    codes_decode: Option<Vec<Vec<(u32, T)>>>,
+    bvs: Vec<BRS>,
+    lens: Vec<usize>,
+    phantom_data: PhantomData<T>,
+}
+
+impl<'de, T, BRS, const COMPRESSED: bool> Deserialize<'de> for WaveletTree<T, BRS, COMPRESSED>
+where
+    T: WTIndexable + Deserialize<'de>,
+    usize: AsPrimitive<T>,
+    BRS: BinRSforWT + Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let decoded = WaveletTreeSerde::<T, BRS>::deserialize(deserializer)?;
+        let _ = decoded.phantom_data;
+        let tree = Self {
+            n: decoded.n,
+            n_levels: decoded.n_levels,
+            sigma: decoded.sigma,
+            codes_encode: decoded.codes_encode,
+            codes_decode: decoded.codes_decode,
+            bvs: decoded.bvs,
+            lens: decoded.lens,
+            phantom_data: PhantomData,
+        };
+        tree.validate_deserialized()
+            .map_err(serde::de::Error::custom)?;
+        Ok(tree)
+    }
+}
+
+struct LenInfo(usize, u32); // symbol, len
 
 #[allow(clippy::identity_op)]
 fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCode> {
@@ -84,6 +124,126 @@ where
     usize: AsPrimitive<T>,
     BRS: BinRSforWT,
 {
+    fn validate_deserialized(&self) -> Result<(), &'static str> {
+        if self.bvs.len() != self.n_levels || self.lens.len() != self.n_levels {
+            return Err("wavelet-tree level metadata has inconsistent lengths");
+        }
+        if self.n == 0 {
+            if self.n_levels != 0
+                || !self.bvs.is_empty()
+                || !self.lens.is_empty()
+                || self.sigma.is_some()
+                || self.codes_encode.is_some()
+                || self.codes_decode.is_some()
+            {
+                return Err("empty wavelet tree contains non-empty metadata");
+            }
+            return Ok(());
+        }
+
+        let type_levels = std::mem::size_of::<T>()
+            .checked_mul(u8::BITS as usize)
+            .ok_or("wavelet-tree type width overflow")?;
+        if self.n_levels == 0 || self.n_levels > type_levels {
+            return Err("wavelet-tree level count exceeds the symbol type width");
+        }
+        if COMPRESSED && self.n_levels > u32::BITS as usize {
+            return Err("compressed wavelet-tree code exceeds 32 bits");
+        }
+
+        for (level, (bv, &len)) in self.bvs.iter().zip(&self.lens).enumerate() {
+            if len > self.n {
+                return Err("wavelet-tree level exceeds the sequence length");
+            }
+            if (len > 0 && AccessBin::get(bv, len - 1).is_none())
+                || AccessBin::get(bv, len).is_some()
+            {
+                return Err("wavelet-tree level length disagrees with its bitvector");
+            }
+            if !COMPRESSED && len != self.n {
+                return Err("plain wavelet-tree levels must match the sequence length");
+            }
+            if COMPRESSED && level > 0 && len > self.lens[level - 1] {
+                return Err("compressed wavelet-tree level lengths must be non-increasing");
+            }
+        }
+        if COMPRESSED && self.lens.first().copied() != Some(self.n) {
+            return Err("compressed wavelet-tree first level must match the sequence length");
+        }
+
+        if COMPRESSED {
+            if self.sigma.is_some() {
+                return Err("compressed wavelet tree must not contain plain sigma metadata");
+            }
+            let encode = self
+                .codes_encode
+                .as_ref()
+                .ok_or("compressed wavelet tree is missing its encoder")?;
+            let decode = self
+                .codes_decode
+                .as_ref()
+                .ok_or("compressed wavelet tree is missing its decoder")?;
+            if decode.len() != self.n_levels + 1 {
+                return Err("compressed wavelet-tree decoder has the wrong depth");
+            }
+            for row in decode {
+                if !row.windows(2).all(|pair| pair[0].0 < pair[1].0) {
+                    return Err("compressed wavelet-tree decoder rows must be strictly sorted");
+                }
+            }
+            for (symbol, code) in encode.iter().enumerate() {
+                if code.len == 0 {
+                    continue;
+                }
+                let code_len = code.len as usize;
+                if code_len > self.n_levels
+                    || (code_len < u32::BITS as usize && code.content >= (1u32 << code_len))
+                {
+                    return Err("compressed wavelet-tree encoder contains an invalid code");
+                }
+                let decoded_symbol = decode[code_len]
+                    .binary_search_by_key(&code.content, |(content, _)| *content)
+                    .ok()
+                    .and_then(|index| decode[code_len].get(index))
+                    .map(|(_, value)| value.as_());
+                if decoded_symbol != Some(symbol) {
+                    return Err("compressed wavelet-tree encode/decode tables disagree");
+                }
+            }
+            for (code_len, row) in decode.iter().enumerate().skip(1) {
+                for &(content, symbol) in row {
+                    let Some(code) = encode.get(symbol.as_()) else {
+                        return Err("compressed wavelet-tree decoder symbol is out of range");
+                    };
+                    if code.len as usize != code_len || code.content != content {
+                        return Err("compressed wavelet-tree decode/encode tables disagree");
+                    }
+                }
+            }
+        } else {
+            if self.codes_encode.is_some() || self.codes_decode.is_some() {
+                return Err("plain wavelet tree contains compressed-code metadata");
+            }
+            let sigma = self
+                .sigma
+                .ok_or("plain wavelet tree is missing sigma metadata")?;
+            if self.n_levels != msb(sigma) as usize + 1 {
+                return Err("plain wavelet-tree sigma disagrees with its level count");
+            }
+        }
+
+        let mut actual_sigma = 0usize;
+        for index in 0..self.n {
+            let symbol = AccessUnsigned::get(self, index)
+                .ok_or("wavelet-tree payload cannot decode every declared position")?;
+            actual_sigma = actual_sigma.max(symbol.as_());
+        }
+        if !COMPRESSED && self.sigma.is_none_or(|sigma| sigma.as_() != actual_sigma) {
+            return Err("plain wavelet-tree sigma disagrees with its encoded payload");
+        }
+        Ok(())
+    }
+
     /// Builds a binary wavelet tree of the `sequence` of unsigned integers.
     /// The input `sequence` will be **destroyed**.
     /// If `[COMPRESSED == true]` the wavelet tree will be compressed, meaning the symbols
@@ -321,8 +481,33 @@ where
         if i >= self.n {
             return None;
         }
-
-        Some(unsafe { self.get_unchecked(i) })
+        let mut cur_i = i;
+        let mut result: u32 = 0;
+        let mut shift = 0;
+        for level in 0..self.n_levels {
+            if COMPRESSED && cur_i >= *self.lens.get(level)? {
+                break;
+            }
+            let bv = self.bvs.get(level)?;
+            let symbol = bv.get(cur_i)?;
+            result = (result << 1) | u32::from(symbol);
+            let ones = bv.rank1(cur_i)?;
+            cur_i = if symbol {
+                ones.checked_add(bv.count_zeros())?
+            } else {
+                cur_i.checked_sub(ones)?
+            };
+            shift += 1;
+        }
+        if COMPRESSED {
+            let leaves = self.codes_decode.as_ref()?.get(shift)?;
+            let index = leaves
+                .binary_search_by_key(&result, |(code, _)| *code)
+                .ok()?;
+            Some(leaves.get(index)?.1)
+        } else {
+            T::from(result)
+        }
     }
 
     #[inline(always)]
@@ -383,12 +568,12 @@ where
     fn occs_range<R: RangeBounds<usize>>(&self, range: R) -> Option<Self::Iter<'_>> {
         let start = match range.start_bound() {
             Bound::Included(start) => *start,
-            Bound::Excluded(start) => *start + 1,
+            Bound::Excluded(start) => start.checked_add(1)?,
             Bound::Unbounded => 0,
         };
 
         let end = match range.end_bound() {
-            Bound::Included(end) => *end + 1,
+            Bound::Included(end) => end.checked_add(1)?,
             Bound::Excluded(end) => *end,
             Bound::Unbounded => self.n,
         };
@@ -450,15 +635,10 @@ where
         while let Some(cur) = self.stack.pop() {
             // have we reached the bottom of the tree? huffman tree needs slightly different logic to check
             if COMPRESSED {
-                // SAFETY: surely it's compressed
-                let codes = unsafe { self.tree.codes_decode.as_ref().unwrap_unchecked() };
-
-                // SAFETY: assumes tree depth corresponds exactly to max code length in codes_decode
-                let leaves = unsafe { codes.get_unchecked(cur.level) };
+                let leaves = self.tree.codes_decode.as_ref()?.get(cur.level)?;
 
                 if let Ok(idx) = leaves.binary_search_by_key(&(cur.bit_path as u32), |(c, _)| *c) {
-                    // SAFETY: we binary searched; if Ok, it definitely exists
-                    let leaf = unsafe { leaves.get_unchecked(idx) };
+                    let leaf = leaves.get(idx)?;
 
                     // prefix free property means we don't descend further here
                     return Some((leaf.1, cur.range.end - cur.range.start));
@@ -467,15 +647,12 @@ where
                 return Some((cur.bit_path.as_(), cur.range.end - cur.range.start));
             }
 
-            // SAFETY: if compressed, a well-formed tree guarantees that we find a leaf above before running
-            // out of levels. if not compressed, we necessarily iterate up to 0..levels.
-            let bv = unsafe { self.tree.bvs.get_unchecked(cur.level) };
+            let bv = self.tree.bvs.get(cur.level)?;
 
             // right child (pushing it first makes non-huffman iterate in lexicographic symbol order)
 
-            // SAFETY: derives from top level bounds check -> valid ranges
-            let r_lo = unsafe { bv.rank1_unchecked(cur.range.start) };
-            let r_hi = unsafe { bv.rank1_unchecked(cur.range.end) };
+            let r_lo = bv.rank1(cur.range.start)?;
+            let r_hi = bv.rank1(cur.range.end)?;
 
             if r_hi > r_lo {
                 let offset = bv.count_zeros();
@@ -521,18 +698,38 @@ where
             return None;
         }
 
-        if !COMPRESSED && symbol > *self.sigma.as_ref().unwrap() {
-            return None;
+        let (symbol_len, repr) = if COMPRESSED {
+            let code = self.codes_encode.as_ref()?.get(symbol.as_())?;
+            if code.len == 0 {
+                return None;
+            }
+            (code.len as usize, code.content)
+        } else {
+            if symbol > *self.sigma.as_ref()? {
+                return None;
+            }
+            (self.n_levels, symbol.as_() as u32)
+        };
+        let mut cur_i = i;
+        let mut cur_p = 0usize;
+        for level in 0..symbol_len {
+            let bit = ((repr >> (symbol_len - level - 1)) & 1) == 1;
+            let bv = self.bvs.get(level)?;
+            let offset = bv.count_zeros();
+            let tmp_p = bv.rank1(cur_p)?;
+            let tmp_i = bv.rank1(cur_i)?;
+            cur_p = if bit {
+                tmp_p.checked_add(offset)?
+            } else {
+                cur_p.checked_sub(tmp_p)?
+            };
+            cur_i = if bit {
+                tmp_i.checked_add(offset)?
+            } else {
+                cur_i.checked_sub(tmp_i)?
+            };
         }
-
-        if COMPRESSED
-            && (symbol.as_() >= self.codes_encode.as_ref().unwrap().len()
-                || self.codes_encode.as_ref().unwrap()[symbol.as_()].len == 0)
-        {
-            return None;
-        }
-
-        Some(unsafe { self.rank_unchecked(symbol, i) })
+        cur_i.checked_sub(cur_p)
     }
 
     #[inline(always)]
@@ -577,21 +774,18 @@ where
 {
     #[inline(always)]
     fn select(&self, symbol: Self::Item, i: usize) -> Option<usize> {
-        if COMPRESSED && self.codes_encode.as_ref().unwrap()[symbol.as_()].len == 0 {
-            return None;
-        }
-
-        let symbol_len;
-        let repr;
-
-        if COMPRESSED {
-            let code = &self.codes_encode.as_ref().unwrap()[symbol.as_()];
-            symbol_len = code.len as usize;
-            repr = code.content;
+        let (symbol_len, repr) = if COMPRESSED {
+            let code = self.codes_encode.as_ref()?.get(symbol.as_())?;
+            if code.len == 0 {
+                return None;
+            }
+            (code.len as usize, code.content)
         } else {
-            repr = symbol.as_() as u32;
-            symbol_len = self.n_levels;
-        }
+            if symbol > *self.sigma.as_ref()? {
+                return None;
+            }
+            (self.n_levels, symbol.as_() as u32)
+        };
         let mut b = 0;
 
         let mut path_off = Vec::with_capacity(symbol_len);
@@ -601,19 +795,11 @@ where
             path_off.push(b);
 
             let bit = ((repr >> (symbol_len - level - 1)) & 1) == 1;
+            let bv = self.bvs.get(level)?;
 
-            let rank_b = if bit {
-                self.bvs[level].rank1(b)
-            } else {
-                self.bvs[level].rank0(b)
-            }?;
+            let rank_b = if bit { bv.rank1(b) } else { bv.rank0(b) }?;
 
-            b = rank_b
-                + if bit {
-                    self.bvs[level].count_zeros()
-                } else {
-                    0
-                };
+            b = rank_b.checked_add(if bit { bv.count_zeros() } else { 0 })?;
 
             rank_path_off.push(rank_b);
         }
@@ -623,12 +809,14 @@ where
             b = path_off[level];
             let rank_b = rank_path_off[level];
             let bit = ((repr >> (symbol_len - level - 1)) & 1) == 1;
+            let bv = self.bvs.get(level)?;
 
-            result = if bit {
-                self.bvs[level].select1(rank_b + result)
+            let selected = if bit {
+                bv.select1(rank_b.checked_add(result)?)
             } else {
-                self.bvs[level].select0(rank_b + result)
-            }? - b;
+                bv.select0(rank_b.checked_add(result)?)
+            }?;
+            result = selected.checked_sub(b)?;
         }
 
         Some(result)

--- a/src/binwt/tests.rs
+++ b/src/binwt/tests.rs
@@ -3,6 +3,48 @@ use crate::{AccessUnsigned, OccsRangeUnsigned, RankUnsigned, SelectUnsigned, HWT
 use rand::RngExt;
 
 #[test]
+fn malformed_deserialized_tree_is_rejected() {
+    #[derive(serde::Serialize)]
+    struct InvalidWaveletTree {
+        n: usize,
+        n_levels: usize,
+        sigma: Option<u32>,
+        codes_encode: Option<Vec<crate::quadwt::huffqwt::PrefixCode>>,
+        codes_decode: Option<Vec<Vec<(u32, u32)>>>,
+        bvs: Vec<crate::BitVector>,
+        lens: Vec<usize>,
+        phantom_data: std::marker::PhantomData<u32>,
+    }
+
+    let bytes = bincode::serialize(&InvalidWaveletTree {
+        n: 1,
+        n_levels: 1,
+        sigma: Some(0),
+        codes_encode: None,
+        codes_decode: None,
+        bvs: Vec::new(),
+        lens: vec![1],
+        phantom_data: std::marker::PhantomData,
+    })
+    .unwrap();
+    assert!(bincode::deserialize::<WT<u32>>(&bytes).is_err());
+}
+
+#[test]
+fn binary_wavelet_trees_round_trip_through_serde() {
+    let data = vec![1u32, 0, 1, 0, 2, 4, 5, 3];
+    let plain = WT::from(data.clone());
+    let compressed = HWT::from(data.clone());
+
+    let plain: WT<u32> = bincode::deserialize(&bincode::serialize(&plain).unwrap()).unwrap();
+    let compressed: HWT<u32> =
+        bincode::deserialize(&bincode::serialize(&compressed).unwrap()).unwrap();
+
+    assert_eq!(plain.iter().collect::<Vec<_>>(), data);
+    assert_eq!(compressed.iter().collect::<Vec<_>>(), data);
+}
+
+#[test]
 fn build_test() {
     let s: Vec<u32> = vec![1, 2, 3, 4, 5, 6, 1, 1, 1, 1, 30000];
 

--- a/src/bitvector/mod.rs
+++ b/src/bitvector/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 use mem_dbg::{MemDbg, MemSize};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 pub mod narrow;
 pub mod wide;
@@ -172,11 +172,60 @@ impl SelectBin for DataLine {
 }
 
 /// Implementation of an immutable bit vector.
-#[derive(Default, Clone, Serialize, Deserialize, MemSize, MemDbg, Eq, PartialEq)]
+#[derive(Default, Clone, Serialize, MemSize, MemDbg, Eq, PartialEq)]
 pub struct BitVector {
     data: Box<[DataLine]>,
     n_bits: usize,
     count_ones: usize,
+}
+
+#[derive(Deserialize)]
+struct BitVectorSerde {
+    data: Box<[DataLine]>,
+    n_bits: usize,
+    count_ones: usize,
+}
+
+fn validate_deserialized_data(data: &[DataLine], n_bits: usize) -> Result<usize, &'static str> {
+    if data.len() != n_bits.div_ceil(512) {
+        return Err("bitvector length disagrees with its data storage");
+    }
+
+    let mut count_ones = 0usize;
+    for (index, &word) in cast_to_u64_slice(data).iter().enumerate() {
+        let bit_start = index.checked_mul(64).ok_or("bitvector length overflow")?;
+        if bit_start >= n_bits {
+            if word != 0 {
+                return Err("bitvector has set bits outside its declared length");
+            }
+            continue;
+        }
+        let used = (n_bits - bit_start).min(64);
+        if used < 64 && word >> used != 0 {
+            return Err("bitvector has set bits outside its declared length");
+        }
+        count_ones = count_ones
+            .checked_add(word.count_ones() as usize)
+            .ok_or("bitvector one count overflow")?;
+    }
+    Ok(count_ones)
+}
+
+impl<'de> Deserialize<'de> for BitVector {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let decoded = BitVectorSerde::deserialize(deserializer)?;
+        let count_ones = validate_deserialized_data(&decoded.data, decoded.n_bits)
+            .map_err(serde::de::Error::custom)?;
+        let _ = decoded.count_ones;
+        Ok(Self {
+            data: decoded.data,
+            n_bits: decoded.n_bits,
+            count_ones,
+        })
+    }
 }
 
 impl BitVector {
@@ -208,7 +257,7 @@ impl BitVector {
     #[must_use]
     #[inline]
     pub fn get_bits(&self, index: usize, len: usize) -> Option<u64> {
-        if (len == 0) | (len > 64) | (index + len > self.n_bits) {
+        if len == 0 || len > 64 || index.checked_add(len)? > self.n_bits {
             return None;
         }
         // SAFETY: safe access due to the above checks
@@ -809,11 +858,35 @@ impl<'a> ExactSizeIterator for BitVectorIter<'a> {
 }
 
 /// Implementation of a mutable bit vector.
-#[derive(Default, Clone, Serialize, Deserialize, MemSize, MemDbg, Eq, PartialEq)]
+#[derive(Default, Clone, Serialize, MemSize, MemDbg, Eq, PartialEq)]
 pub struct BitVectorMut {
     data: Vec<DataLine>,
     n_bits: usize,
     count_ones: usize,
+}
+
+#[derive(Deserialize)]
+struct BitVectorMutSerde {
+    data: Vec<DataLine>,
+    n_bits: usize,
+    count_ones: usize,
+}
+
+impl<'de> Deserialize<'de> for BitVectorMut {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let decoded = BitVectorMutSerde::deserialize(deserializer)?;
+        let count_ones = validate_deserialized_data(&decoded.data, decoded.n_bits)
+            .map_err(serde::de::Error::custom)?;
+        let _ = decoded.count_ones;
+        Ok(Self {
+            data: decoded.data,
+            n_bits: decoded.n_bits,
+            count_ones,
+        })
+    }
 }
 
 impl BitVectorMut {
@@ -1078,7 +1151,7 @@ impl BitVectorMut {
     #[must_use]
     #[inline]
     pub fn get_bits(&self, index: usize, len: usize) -> Option<u64> {
-        if (len == 0) | (len > 64) | (index + len >= self.n_bits) {
+        if len == 0 || len > 64 || index.checked_add(len)? > self.n_bits {
             return None;
         }
         // SAFETY: safe access due to the above checks

--- a/src/bitvector/narrow.rs
+++ b/src/bitvector/narrow.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use mem_dbg::{MemDbg, MemSize};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 //block_rank_pairs layout
 //|superblock0|block0|superblock1|block1...
@@ -18,11 +18,31 @@ const BLOCK_SIZE: usize = 8; // in 64bit words
 const SELECT_ONES_PER_HINT: usize = 64 * BLOCK_SIZE * 2; // must be > block_size * 64
 const SELECT_ZEROS_PER_HINT: usize = SELECT_ONES_PER_HINT;
 
-#[derive(Clone, Default, Serialize, Deserialize, Debug, Eq, PartialEq, MemSize, MemDbg)]
+#[derive(Clone, Default, Serialize, Debug, Eq, PartialEq, MemSize, MemDbg)]
 pub struct RS {
     bv: BitVector,
     block_rank_pairs: Box<[u64]>,
     select_samples: [Box<[usize]>; 2],
+}
+
+#[derive(Deserialize)]
+struct RSSerde {
+    bv: BitVector,
+    block_rank_pairs: Box<[u64]>,
+    select_samples: [Box<[usize]>; 2],
+}
+
+impl<'de> Deserialize<'de> for RS {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let decoded = RSSerde::deserialize(deserializer)?;
+        // Rank/select metadata is a cache derived from the bitvector. Rebuild it
+        // instead of trusting persisted offsets that feed unchecked operations.
+        let _ = (decoded.block_rank_pairs, decoded.select_samples);
+        Ok(Self::new(decoded.bv))
+    }
 }
 
 impl RS {
@@ -123,7 +143,7 @@ impl RS {
     /// Returns the number of bits set to 1 in the bitvector.
     #[inline(always)]
     pub fn count_ones(&self) -> usize {
-        self.rank1(self.bv.len() - 1).unwrap() + self.bv.get(self.bv.len() - 1).unwrap() as usize
+        self.bv.count_ones()
     }
 
     /// Returns the number of bits set to 0 in the bitvector.

--- a/src/bitvector/rs_tests.rs
+++ b/src/bitvector/rs_tests.rs
@@ -30,6 +30,10 @@ macro_rules! generate_rs_tests {
 
                 assert_eq!(rs.rank1(0), None);
                 assert_eq!(rs.rank1(100), None);
+                assert_eq!(rs.count_ones(), 0);
+                assert_eq!(rs.count_zeros(), 0);
+                assert_eq!(rs.select1(0), None);
+                assert_eq!(rs.select0(0), None);
             }
             // Tests a bit vector where the last bit of l2 is set
             #[test]
@@ -138,3 +142,47 @@ macro_rules! generate_rs_tests {
 
 generate_rs_tests!(narrow, crate::bitvector::narrow::RS);
 generate_rs_tests!(wide, crate::bitvector::wide::RS);
+
+#[test]
+fn narrow_serde_rebuilds_rank_select_metadata() {
+    #[derive(serde::Serialize)]
+    struct NarrowRsWithBadCache<'a> {
+        bv: &'a BitVector,
+        block_rank_pairs: Box<[u64]>,
+        select_samples: [Box<[usize]>; 2],
+    }
+
+    let bv: BitVector = [true, false, true].into_iter().collect();
+    let bytes = bincode::serialize(&NarrowRsWithBadCache {
+        bv: &bv,
+        block_rank_pairs: Vec::new().into_boxed_slice(),
+        select_samples: [Vec::new().into_boxed_slice(), Vec::new().into_boxed_slice()],
+    })
+    .unwrap();
+    let rs = bincode::deserialize::<crate::bitvector::narrow::RS>(&bytes).unwrap();
+    assert_eq!(rs.rank1(3), Some(2));
+    assert_eq!(rs.select1(1), Some(2));
+}
+
+#[test]
+fn wide_serde_rebuilds_rank_select_metadata() {
+    #[derive(serde::Serialize)]
+    struct WideRsWithBadCache<'a> {
+        bv: &'a BitVector,
+        superblock_metadata: Box<[u128]>,
+        select_samples: [Box<[usize]>; 2],
+        count_zeros: usize,
+    }
+
+    let bv: BitVector = [true, false, true].into_iter().collect();
+    let bytes = bincode::serialize(&WideRsWithBadCache {
+        bv: &bv,
+        superblock_metadata: Vec::new().into_boxed_slice(),
+        select_samples: [Vec::new().into_boxed_slice(), Vec::new().into_boxed_slice()],
+        count_zeros: usize::MAX,
+    })
+    .unwrap();
+    let rs = bincode::deserialize::<crate::bitvector::wide::RS>(&bytes).unwrap();
+    assert_eq!(rs.rank1(3), Some(2));
+    assert_eq!(rs.select0(0), Some(1));
+}

--- a/src/bitvector/tests.rs
+++ b/src/bitvector/tests.rs
@@ -1,4 +1,64 @@
 use super::*;
+
+#[test]
+fn serde_rejects_length_outside_data_capacity() {
+    #[derive(serde::Serialize)]
+    struct InvalidBitVector {
+        data: Box<[DataLine]>,
+        n_bits: usize,
+        count_ones: usize,
+    }
+
+    let bytes = bincode::serialize(&InvalidBitVector {
+        data: Vec::new().into_boxed_slice(),
+        n_bits: 1,
+        count_ones: 0,
+    })
+    .unwrap();
+    assert!(bincode::deserialize::<BitVector>(&bytes).is_err());
+}
+
+#[test]
+fn serde_rejects_set_bits_after_declared_length() {
+    #[derive(serde::Serialize)]
+    struct InvalidBitVector {
+        data: Box<[DataLine]>,
+        n_bits: usize,
+        count_ones: usize,
+    }
+
+    let mut line = DataLine::default();
+    line.words[0] = 0b10;
+    let bytes = bincode::serialize(&InvalidBitVector {
+        data: vec![line].into_boxed_slice(),
+        n_bits: 1,
+        count_ones: 0,
+    })
+    .unwrap();
+    assert!(bincode::deserialize::<BitVector>(&bytes).is_err());
+}
+
+#[test]
+fn serde_rebuilds_cached_one_count() {
+    #[derive(serde::Serialize)]
+    struct BitVectorWithBadCache {
+        data: Box<[DataLine]>,
+        n_bits: usize,
+        count_ones: usize,
+    }
+
+    let mut line = DataLine::default();
+    line.words[0] = 1;
+    let bytes = bincode::serialize(&BitVectorWithBadCache {
+        data: vec![line].into_boxed_slice(),
+        n_bits: 1,
+        count_ones: usize::MAX,
+    })
+    .unwrap();
+    let bitvector = bincode::deserialize::<BitVector>(&bytes).unwrap();
+    assert_eq!(bitvector.count_ones(), 1);
+    assert_eq!(bitvector.count_zeros(), 0);
+}
 use crate::perf_and_test_utils::{gen_strictly_increasing_sequence, negate_vector};
 
 #[test]
@@ -58,13 +118,17 @@ fn test_get_set_bits() {
     assert_eq!(bv.get_bits(61, 35).unwrap(), 0);
     assert_eq!(bv.get_bits(0, 42).unwrap(), 0);
     assert_eq!(bv.get_bits(n - 42 - 1, 42).unwrap(), 0);
-    assert_eq!(bv.get_bits(n - 42, 42), None);
+    assert_eq!(bv.get_bits(n - 42, 42), Some(0));
+    assert_eq!(bv.get_bits(usize::MAX, 1), None);
     bv.set_bits(0, 6, 42);
     assert_eq!(bv.get_bits(0, 6).unwrap(), 42);
     bv.set_bits(n - 61 - 1, 61, 42);
     assert_eq!(bv.get_bits(n - 61 - 1, 61).unwrap(), 42);
     bv.set_bits(n - 67 - 1, 33, 42);
     assert_eq!(bv.get_bits(n - 67 - 1, 33).unwrap(), 42);
+
+    let immutable: BitVector = bv.into();
+    assert_eq!(immutable.get_bits(usize::MAX, 1), None);
 }
 
 #[test]

--- a/src/bitvector/wide.rs
+++ b/src/bitvector/wide.rs
@@ -4,7 +4,7 @@
 use crate::{utils::prefetch_read_NTA, AccessBin, BitVector, RankBin, SelectBin};
 
 use mem_dbg::{MemDbg, MemSize};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 //superblock is 44 bits, blocks are (BLOCK_SIZE-1) * 12 bits each
 const BLOCK_SIZE: usize = 8; // 8 64bit words for each block
@@ -13,12 +13,37 @@ const SUPERBLOCK_SIZE: usize = 8 * BLOCK_SIZE; // 8 blocks for each superblock (
 const SELECT_ONES_PER_HINT: usize = 64 * SUPERBLOCK_SIZE * 2; // must be > superblock_size * 64
 const SELECT_ZEROS_PER_HINT: usize = SELECT_ONES_PER_HINT;
 
-#[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize, MemSize, MemDbg, Debug)]
+#[derive(Clone, Default, Eq, PartialEq, Serialize, MemSize, MemDbg, Debug)]
 pub struct RS {
     bv: BitVector,
     superblock_metadata: Box<[u128]>, // in each u128 we store the pair (superblock, <7 blocks>) like so |L1  |L2|L2|L2|L2|L2|L2|L2|
     select_samples: [Box<[usize]>; 2],
     count_zeros: usize,
+}
+
+#[derive(Deserialize)]
+struct RSSerde {
+    bv: BitVector,
+    superblock_metadata: Box<[u128]>,
+    select_samples: [Box<[usize]>; 2],
+    count_zeros: usize,
+}
+
+impl<'de> Deserialize<'de> for RS {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let decoded = RSSerde::deserialize(deserializer)?;
+        // All remaining fields are caches derived from the bitvector and must
+        // not be trusted across the persistence boundary.
+        let _ = (
+            decoded.superblock_metadata,
+            decoded.select_samples,
+            decoded.count_zeros,
+        );
+        Ok(Self::new(decoded.bv))
+    }
 }
 
 impl RS {

--- a/src/qvector/mod.rs
+++ b/src/qvector/mod.rs
@@ -12,7 +12,7 @@ use mem_dbg::{MemDbg, MemSize};
 use num_traits::int::PrimInt;
 use num_traits::AsPrimitive;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 // A quad vector is made of `DataLine`s. Each line consists of
 // four u128, so each `DataLine` is 512 bits and fits in a cache line.
@@ -129,10 +129,36 @@ impl RankQuad for DataLine {
 
 // The trait SelectQuad is not implemented because RSSupport needs to it by hand :-)
 
-#[derive(Clone, Default, Eq, PartialEq, Serialize, MemSize, MemDbg, Deserialize, Debug)]
+#[derive(Clone, Default, Eq, PartialEq, Serialize, MemSize, MemDbg, Debug)]
 pub struct QVector {
     data: Box<[DataLine]>,
     position: usize,
+}
+
+#[derive(Deserialize)]
+struct QVectorSerde {
+    data: Box<[DataLine]>,
+    position: usize,
+}
+
+impl<'de> Deserialize<'de> for QVector {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let decoded = QVectorSerde::deserialize(deserializer)?;
+        if !decoded.position.is_multiple_of(2)
+            || decoded.position > decoded.data.len().saturating_mul(512)
+        {
+            return Err(serde::de::Error::custom(
+                "QVector position is outside its data capacity",
+            ));
+        }
+        Ok(Self {
+            data: decoded.data,
+            position: decoded.position,
+        })
+    }
 }
 
 impl QVector {

--- a/src/qvector/rs_qvector.rs
+++ b/src/qvector/rs_qvector.rs
@@ -8,7 +8,7 @@ use mem_dbg::{MemDbg, MemSize};
 use num_traits::int::PrimInt;
 use num_traits::{AsPrimitive, Unsigned};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 // Traits
 use crate::{AccessQuad, RankQuad, SelectQuad, WTSupport};
@@ -23,11 +23,36 @@ pub type RSQVector512 = RSQVector<RSSupportPlain<512>>;
 
 /// The generic `S` is the data structure used to provide rank/select
 /// support at the level of blocks.
-#[derive(Default, Clone, PartialEq, Debug, Serialize, MemSize, MemDbg, Deserialize)]
+#[derive(Default, Clone, PartialEq, Debug, Serialize, MemSize, MemDbg)]
 pub struct RSQVector<S> {
     qv: QVector,
     rs_support: S,
     n_occs_smaller: [usize; 5], // for each symbol c, store the number of occurrences of in qv of symbols smaller than c. We store 5 (instead of 4) counters so we can use them to compute also the number of occurrences of each symbol without branches.
+}
+
+#[derive(Deserialize)]
+struct RSQVectorSerde<S> {
+    qv: QVector,
+    rs_support: S,
+    n_occs_smaller: [usize; 5],
+}
+
+impl<'de, S> Deserialize<'de> for RSQVector<S>
+where
+    S: RSSupport + Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let decoded = RSQVectorSerde::<S>::deserialize(deserializer)?;
+        // Rank/select support is persisted only as a cache. Rebuild it from
+        // the validated QVector so crafted counters can never reach unsafe
+        // query primitives.
+        let _ = decoded.rs_support;
+        let _ = decoded.n_occs_smaller;
+        Ok(Self::from(decoded.qv))
+    }
 }
 
 impl<S> RSQVector<S> {
@@ -277,7 +302,7 @@ impl<S> AccessQuad for RSQVector<S> {
 
 impl<S: RSSupport> RankQuad for RSQVector<S> {
     /// Returns rank of `symbol` up to position `i` **excluded**.
-    /// Returns `None` if out of bounds.
+    /// Returns `None` if `i` is out of bounds or `symbol` is not in [0..3].
     ///
     /// # Examples
     /// ```
@@ -293,10 +318,10 @@ impl<S: RSSupport> RankQuad for RSQVector<S> {
     /// ```
     #[inline(always)]
     fn rank(&self, symbol: u8, i: usize) -> Option<usize> {
-        if i > self.qv.len() {
+        if symbol > 3 || i > self.qv.len() {
             return None;
         }
-        // Safety: The check above guarantees we are not out of bound
+        // Safety: The checks above guarantee a valid symbol and position.
         Some(unsafe { self.rank_unchecked(symbol, i) })
     }
 
@@ -308,7 +333,7 @@ impl<S: RSSupport> RankQuad for RSQVector<S> {
     #[inline(always)]
     unsafe fn rank_unchecked(&self, symbol: u8, i: usize) -> usize {
         debug_assert!(symbol <= 3);
-        self.rs_support.rank_block(symbol, i) + self.rank_intra_block(symbol, i)
+        (unsafe { self.rs_support.rank_block(symbol, i) }) + self.rank_intra_block(symbol, i)
     }
 }
 
@@ -335,7 +360,9 @@ impl<S: RSSupport> SelectQuad for RSQVector<S> {
             return None;
         }
 
-        let (mut pos, rank) = self.rs_support.select_block(symbol, i + 1);
+        // SAFETY: the occurrence count check above proves the requested
+        // sample exists in support derived from this QVector.
+        let (mut pos, rank) = unsafe { self.rs_support.select_block(symbol, i + 1) };
 
         // if rank == i {
         //     return Some(pos);
@@ -418,7 +445,7 @@ impl<S: RSSupport> WTSupport for RSQVector<S> {
     /// if the position `i` is out of bound is undefined behavior.
     #[inline(always)]
     unsafe fn rank_block_unchecked(&self, symbol: u8, i: usize) -> usize {
-        self.rs_support.rank_block(symbol, i)
+        unsafe { self.rs_support.rank_block(symbol, i) }
     }
 
     /// Prefetches counters of the superblock and blocks containing the position `pos`.
@@ -474,12 +501,18 @@ pub trait RSSupport {
     /// of the block that contains position `i`.
     ///
     /// We use a const generic to have a specialized method for each symbol.
-    fn rank_block(&self, symbol: u8, i: usize) -> usize;
+    /// # Safety
+    /// `symbol` must be in `0..4`, and `i` must be a valid position in the
+    /// QVector from which this support was built.
+    unsafe fn rank_block(&self, symbol: u8, i: usize) -> usize;
 
     /// Returns a pair `(position, rank)` where the position is the beginning of the block
     /// that contains the `i`th occurrence of `symbol`, and `rank` is the number of
     /// occurrences of `symbol` up to the beginning of this block.
-    fn select_block(&self, symbol: u8, i: usize) -> (usize, usize);
+    /// # Safety
+    /// `symbol` must be in `0..4`, and `i` must name an existing occurrence
+    /// in the QVector from which this support was built.
+    unsafe fn select_block(&self, symbol: u8, i: usize) -> (usize, usize);
 
     fn prefetch(&self, pos: usize);
 }
@@ -514,6 +547,18 @@ mod tests {
         assert_eq!(rsqv.rank(1, 256), Some(0));
         assert_eq!(rsqv.rank(2, 256), Some(0));
         assert_eq!(rsqv.rank(3, 256), Some(0));
+    }
+
+    #[test]
+    fn test_rank_rejects_invalid_symbols<D>()
+    where
+        D: From<QVector> + RankQuad,
+    {
+        let qv: QVector = [0, 1, 2, 3].into_iter().collect();
+        let rsqv = D::from(qv);
+
+        assert_eq!(rsqv.rank(4, 0), None);
+        assert_eq!(rsqv.rank(u8::MAX, 4), None);
     }
 
     #[test]

--- a/src/qvector/rs_qvector/rs_support_plain.rs
+++ b/src/qvector/rs_qvector/rs_support_plain.rs
@@ -15,10 +15,16 @@ use serde::{Deserialize, Serialize};
 /// The possible values are 256 (default) and 512.
 /// The space overhead for 256 is 12.5% while 512 halves this
 /// space overhead (6.25%) at the cost of (slightly) increasing the query time.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, MemSize, MemDbg, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, MemSize, MemDbg, PartialEq)]
 pub struct RSSupportPlain<const B_SIZE: usize = 256> {
     superblocks: Box<[SuperblockPlain]>,
     select_samples: [Box<[u32]>; 4],
+}
+
+impl<const B_SIZE: usize> Default for RSSupportPlain<B_SIZE> {
+    fn default() -> Self {
+        Self::new(&QVector::default())
+    }
 }
 
 impl<const B_SIZE: usize> RSSupport for RSSupportPlain<B_SIZE> {
@@ -126,7 +132,7 @@ impl<const B_SIZE: usize> RSSupport for RSSupportPlain<B_SIZE> {
     /// Returns the number of occurrences of `symbol` up to the beginning
     /// of the block that contains position `i`.
     #[inline(always)]
-    fn rank_block(&self, symbol: u8, i: usize) -> usize {
+    unsafe fn rank_block(&self, symbol: u8, i: usize) -> usize {
         debug_assert!(symbol <= 3, "Symbols are in [0, 3].");
 
         let superblock_index = Self::superblock_index(i);
@@ -145,7 +151,7 @@ impl<const B_SIZE: usize> RSSupport for RSSupportPlain<B_SIZE> {
     ///
     /// The caller must guarantee that `i` is not zero or greater than the length of the indexed sequence.
     #[inline(always)]
-    fn select_block(&self, symbol: u8, i: usize) -> (usize, usize) {
+    unsafe fn select_block(&self, symbol: u8, i: usize) -> (usize, usize) {
         let sampled_i = (i - 1) / Self::SELECT_NUM_SAMPLES;
 
         let mut first_sblock_id = self.select_samples[symbol as usize][sampled_i] as usize;
@@ -234,7 +240,12 @@ impl SuperblockPlain {
 
     #[inline(always)]
     fn get_rank(&self, symbol: u8, block_id: usize) -> usize {
-        let data = unsafe { *self.counters.get_unchecked(symbol as usize) };
+        assert!(symbol < 4, "symbols are in [0, 3]");
+        assert!(
+            block_id < Self::BLOCKS_IN_SUPERBLOCK,
+            "block id is in [0, 7]"
+        );
+        let data = self.counters[symbol as usize];
         let sb = (data >> 84) as usize;
 
         // We avoid a branch here. We want b be 0 if block_id is 0, real counter extracted from data otherwise
@@ -245,7 +256,8 @@ impl SuperblockPlain {
     }
 
     fn get_superblock_counter(&self, symbol: u8) -> usize {
-        (unsafe { *self.counters.get_unchecked(symbol as usize) } >> 84) as usize
+        assert!(symbol < 4, "symbols are in [0, 3]");
+        (self.counters[symbol as usize] >> 84) as usize
     }
 
     fn set_block_counters(&mut self, block_id: usize, counters: &[usize; 4]) {
@@ -281,6 +293,7 @@ impl SuperblockPlain {
     /// predecessor x of a 12bit value in the last 84 bits of a u128.
     #[inline(always)]
     pub fn block_predecessor(&self, symbol: u8, target: usize) -> (usize, usize) {
+        assert!(symbol < 4, "symbols are in [0, 3]");
         let mut cnt = self.counters[symbol as usize];
         let mut prev_cnt = 0;
 

--- a/src/qvector/tests.rs
+++ b/src/qvector/tests.rs
@@ -1,6 +1,22 @@
 use super::*;
 
 #[test]
+fn serde_rejects_position_outside_data_capacity() {
+    #[derive(serde::Serialize)]
+    struct InvalidQVector {
+        data: Box<[DataLine]>,
+        position: usize,
+    }
+
+    let bytes = bincode::serialize(&InvalidQVector {
+        data: Vec::new().into_boxed_slice(),
+        position: 2,
+    })
+    .unwrap();
+    assert!(bincode::deserialize::<QVector>(&bytes).is_err());
+}
+
+#[test]
 fn test_empty() {
     let qv = QVector::default();
     assert!(qv.is_empty());
@@ -9,6 +25,13 @@ fn test_empty() {
     let qv: QVector = [0, 1, 2, 3].into_iter().cycle().take(10).collect();
     assert!(!qv.is_empty());
     assert_eq!(qv.len(), 10);
+}
+
+#[test]
+fn default_rank_support_has_a_valid_empty_sentinel() {
+    let qv = crate::RSQVector256::default();
+    assert_eq!(crate::RankQuad::rank(&qv, 0, 0), Some(0));
+    assert_eq!(crate::SelectQuad::select(&qv, 0, 0), None);
 }
 
 #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -185,38 +185,21 @@ pub fn popcnt_wide<const N: usize>(data: &[u64]) -> usize {
     res
 }
 
-use std::mem;
-
 use crate::quadwt::huffqwt::PrefixCode;
 
-#[repr(C, align(64))]
-struct AlignToSixtyFour([u8; 64]);
-
-/// Returns a 64-byte aligned vector of T with at least the
-/// given capacity.
+/// Returns a vector with at least the given capacity when `T` itself has
+/// 64-byte alignment.
 ///
-/// Todo: make this safe by checking invariants.
-///
-/// # Safety
-/// See Safety of [Vec::Vec::from_raw_parts](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.from_raw_parts).
-pub unsafe fn get_64byte_aligned_vector<T>(capacity: usize) -> Vec<T> {
-    assert!(mem::size_of::<T>() <= mem::size_of::<AlignToSixtyFour>());
-    assert!(mem::size_of::<AlignToSixtyFour>().is_multiple_of(mem::size_of::<T>())); // must divide otherwise fro raw parts below doesnt work
-
-    let n_units = (capacity * mem::size_of::<T>()).div_ceil(mem::size_of::<AlignToSixtyFour>());
-    let mut aligned: Vec<AlignToSixtyFour> = Vec::with_capacity(n_units);
-
-    let ptr = aligned.as_mut_ptr();
-    let len_units = aligned.len();
-    let cap_units = aligned.capacity();
-
-    mem::forget(aligned);
-
-    Vec::from_raw_parts(
-        ptr as *mut T,
-        len_units * mem::size_of::<AlignToSixtyFour>() / mem::size_of::<T>(),
-        cap_units * mem::size_of::<AlignToSixtyFour>() / mem::size_of::<T>(),
-    )
+/// A standard `Vec<T>` must be allocated and deallocated with `T`'s exact
+/// layout. It cannot safely over-align ordinary element types by casting an
+/// allocation made for another type. Callers that need 64-byte alignment for
+/// smaller-alignment elements must use an owning aligned-buffer type instead.
+pub fn get_64byte_aligned_vector<T>(capacity: usize) -> Vec<T> {
+    assert!(
+        std::mem::align_of::<T>() >= 64,
+        "T must itself have at least 64-byte alignment"
+    );
+    Vec::with_capacity(capacity)
 }
 
 /// Computes the position of the most significant bit in v.

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -1,6 +1,19 @@
 use super::*;
 
 #[test]
+fn aligned_vector_requires_an_aligned_element_layout() {
+    #[repr(align(64))]
+    struct Aligned([u8; 64]);
+
+    let mut vector = get_64byte_aligned_vector::<Aligned>(2);
+    vector.push(Aligned([0; 64]));
+    assert!(vector.capacity() >= 2);
+    assert_eq!((vector.as_ptr() as usize) % 64, 0);
+    assert_eq!(vector[0].0[0], 0);
+    assert!(std::panic::catch_unwind(|| get_64byte_aligned_vector::<u8>(1)).is_err());
+}
+
+#[test]
 fn test_select_in_word() {
     assert_eq!(select_in_word(1, 0), 0);
     assert_eq!(select_in_word(2, 0), 1);


### PR DESCRIPTION
## Summary

Hardens the persistence boundary for the core succinct data structures without depending on the byte-layout work in #32.

- validate binary wavelet-tree level metadata, symbol widths, Huffman code tables, and encoded payloads during deserialization
- validate BitVector storage length and unused tail bits, then rebuild cached one counts and rank/select indexes
- validate QVector positions, rebuild RSQVector rank/select support, and reject invalid rank symbols
- replace the cross-layout `Vec::from_raw_parts` alignment cast with layout-correct allocation
- replace safe query paths that trusted persisted structure with checked indexing and checked arithmetic

## Security impact

Malformed Serde/bincode input could previously supply inconsistent lengths or attacker-controlled derived caches that were later consumed by unchecked query primitives. The new deserializers validate primary storage and reconstruct derived metadata before the values become usable through safe APIs.

## Relationship to existing PRs

This supersedes the narrower fixes in #35 and #36. It is intentionally based directly on `main`. Validation for the QWTB/HQWB byte layouts and borrowed views will follow separately on top of #32.

## Verification

- `cargo test --all-features`: 208 passed
- `cargo fmt --all -- --check`: clean
- `cargo clippy --lib --all-features`: completes successfully (28 warnings already present on upstream `main`)
- `cargo clippy --all-targets --all-features` remains blocked by upstream test fixtures denied by `clippy::reversed_empty_ranges`
- `git diff --check`: clean
