### PR TITLE
Harden QWTB/HQWB decoding and Huffman validation

### DIFF
--- a/PR2_BODY.md
+++ b/PR2_BODY.md
@@ -1,0 +1,58 @@
+# Add first-class byte layout and zero-copy I/O for QWT / HQWT
+
+## Summary
+
+Adds a stable little-endian on-disk / in-memory byte container for plain and Huffman quad wavelet trees, with both **owned** round-trips and **zero-copy borrowed views**. The crate never depends on an mmap library — the caller owns the buffer (heap `Vec`, `AlignedBytes`, or a page-aligned mmap).
+
+This is complementary to the existing serde/`bincode` path, which is left unchanged.
+
+Depends on / builds on #31 (`range-successor-and-fused-rank`).
+
+## API
+
+| Container | Tree | Owned | Zero-copy |
+| --- | --- | --- | --- |
+| `QWTB` | plain QWT 256/512 | `qwt256_to_bytes` / `qwt256_from_bytes` (+ `qwt512_*`) | `QwtView` |
+| `HQWB` | Huffman QWT 256/512 | `hqwt256_to_bytes` / `hqwt256_from_bytes` (+ `hqwt512_*`) | `HqwtView` |
+
+Supporting pieces:
+
+- `LayoutError` — magic / version / truncation / misalignment / endianness / prefetch
+- `RSQVectorView` — per-level borrowed get/rank/select + POD accessors for custom hot paths
+- `AlignedBytes` — over-allocated buffer exposing a 64-aligned window (needed when opening a view over a heap `Vec`)
+- Raw-parts constructors (`QVector::from_raw_parts`, `RSSupportPlain::from_parts`, `QWaveletTree::from_parts`, …) used by the owned decode path
+
+Views implement the same `AccessUnsigned` / `RankUnsigned` / `SelectUnsigned` traits as the owned trees.
+
+## Format (v1)
+
+Little-endian only. Header is 32 bytes; plain level directories are 128 B; HQWT directories add `level_len` (136 B). POD payloads (`DataLine`, `SuperblockPlain`) are 64-aligned within the blob. Flags: bit0 = B_SIZE=512, bit1 = prefetch (rejected in v1 with `PrefetchNotSupported`).
+
+Owned decode copies POD slices onto the heap, so the source buffer need not be 64-aligned. Zero-copy views cast in place and therefore require a 64-aligned absolute base (satisfied by page-aligned mmaps or `AlignedBytes`).
+
+## Design choices
+
+- **No new dependencies, no feature flags.** Serde path untouched.
+- **Caller owns mmap.** Keeps this crate free of `memmap2`/etc. and lets embedders control mapping lifetime.
+- **Prefetch trees out of scope for v1.** Can be added later behind a new flag/version without breaking the plain layout.
+- **Layout fields stay crate-private.** Computational APIs and the new bytes/view surface are the public path; we do not expose internal POD fields for external mmap parsing.
+
+## Testing
+
+- Round-trip get/rank/select for QWTB and HQWB (including empty trees and large/skewed alphabets)
+- View parity vs owned trees; unaligned-base rejection; bad-magic errors
+- Full crate: `cargo test --lib` (110) and `cargo clippy --lib --all-targets -- -D warnings` clean
+
+## Docs
+
+- New README section **Byte layout and zero-copy I/O** with a short example
+- Module and public-fn docs on the `bytes` API
+
+## Checklist
+
+- [x] Owned `to_bytes` / `from_bytes` for QWTB + HQWB
+- [x] Zero-copy `QwtView` / `HqwtView`
+- [x] Overflow-safe decode of untrusted headers (`checked_region`)
+- [x] Clippy clean under `-D warnings`
+- [x] README + rustdoc
+- [ ] (optional follow-up) example that mmaps a `.qwtb` file end-to-end

--- a/README.md
+++ b/README.md
@@ -262,6 +262,51 @@ assert_eq!(wt.iter().collect::<Vec<_>>(), hqwt.iter().collect::<Vec<_>>());
 
 ```
 
+## <a name="bytes">Byte layout and zero-copy I/O</a>
+
+In addition to serde/`bincode`, plain and Huffman quad wavelet trees can be
+serialized to a stable little-endian byte container and opened either as an
+**owned** tree or as a **zero-copy borrowed view** over caller-owned bytes
+(for example an `mmap` region). The crate never depends on an mmap library —
+the caller owns the buffer.
+
+| Container | Tree | Owned API | Zero-copy view |
+| :-------- | :--- | :-------- | :------------- |
+| `QWTB` | plain QWT 256/512 | `qwt256_to_bytes` / `qwt256_from_bytes` (and `qwt512_*`) | [`QwtView`] |
+| `HQWB` | Huffman QWT 256/512 | `hqwt256_to_bytes` / `hqwt256_from_bytes` (and `hqwt512_*`) | [`HqwtView`] |
+
+Both paths live in the [`bytes`](https://docs.rs/qwt/latest/qwt/bytes/) module
+and implement the same `AccessUnsigned` / `RankUnsigned` / `SelectUnsigned`
+traits as the owned trees.
+
+```rust
+use qwt::bytes::{qwt256_to_bytes, qwt256_from_bytes, QwtView, AlignedBytes};
+use qwt::{AccessUnsigned, QWT256};
+
+let qwt = QWT256::from(vec![1u8, 0, 1, 0, 2, 4, 5, 3]);
+
+// Owned round-trip (copies POD payloads onto the heap; source need not be aligned)
+let bytes = qwt256_to_bytes(&qwt).unwrap();
+let owned: QWT256<u8> = qwt256_from_bytes(&bytes).unwrap();
+assert_eq!(owned.get(2), Some(1));
+
+// Zero-copy view (requires a 64-byte-aligned base; use AlignedBytes or an mmap page)
+let aligned = AlignedBytes::from_slice(&bytes);
+let view = QwtView::<u8, 256>::from_bytes(aligned.as_slice()).unwrap();
+assert_eq!(view.get(2), Some(1));
+assert_eq!(view.rank(1, 4), owned.rank(1, 4));
+```
+
+Notes:
+
+- Format is **little-endian only** (v1). Big-endian hosts get `LayoutError::NotLittleEndian`.
+- Prefetch-augmented trees (`*Pfs`) are not supported in v1 (`LayoutError::PrefetchNotSupported`).
+- Zero-copy views cast `DataLine` / `SuperblockPlain` POD slices in place, so the
+  absolute base address of the buffer must be 64-byte aligned. `AlignedBytes`
+  copies into an over-allocated buffer and exposes a 64-aligned window; page-aligned
+  mmaps satisfy the requirement naturally.
+- The existing serde/`bincode` path is unchanged.
+
 We can index any sequence over any [num::traits::Unsigned](https://docs.rs/num/latest/num/traits/trait.Unsigned.html) integers. 
 As the space usage depends on the largest value in the sequence, it could be worth remapping the values to remove "holes".
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ traits as the owned trees.
 
 ```rust
 use qwt::bytes::{qwt256_to_bytes, qwt256_from_bytes, QwtView, AlignedBytes};
-use qwt::{AccessUnsigned, QWT256};
+use qwt::{AccessUnsigned, RankUnsigned, QWT256};
 
 let qwt = QWT256::from(vec![1u8, 0, 1, 0, 2, 4, 5, 3]);
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 ## TODO
 - Use a binary vector at the first level when log sigma is odd.
 - Implement an efficient iterator over a Wavelet Tree.
-- Implement a binary wavelet tree.
+  - Partially addressed by `RangeDistinctIter` (fixed-stack distinct-symbol
+    enumerator over a row range). A full position / value iterator is still open.
+- Implement a binary wavelet tree. (`binwt` remains a stub.)
 - Replace From with TryFrom
 - Implement DoubleEndedIterator for all the collections

--- a/examples/perf_darray.rs
+++ b/examples/perf_darray.rs
@@ -1,8 +1,7 @@
+use mem_dbg::{MemSize, SizeFlags};
 use qwt::perf_and_test_utils::{
     gen_queries, gen_strictly_increasing_sequence, type_of, TimingQueries,
 };
-
-use mem_dbg::{MemSize, SizeFlags};
 use qwt::{DArray, SelectBin};
 
 fn main() {

--- a/examples/perf_rs_narrow.rs
+++ b/examples/perf_rs_narrow.rs
@@ -1,9 +1,7 @@
 use mem_dbg::{MemSize, SizeFlags};
-use qwt::{
-    narrow::RS,
-    perf_and_test_utils::{gen_queries, type_of, TimingQueries},
-    RankBin, SelectBin,
-};
+use qwt::narrow::RS;
+use qwt::perf_and_test_utils::{gen_queries, type_of, TimingQueries};
+use qwt::{RankBin, SelectBin};
 
 const N_RUNS: usize = 5;
 const N_QUERIES: usize = 10_000_000;

--- a/examples/perf_rs_qvector.rs
+++ b/examples/perf_rs_qvector.rs
@@ -1,7 +1,6 @@
 use mem_dbg::{MemSize, SizeFlags};
 use qwt::perf_and_test_utils::{gen_queries, type_of, TimingQueries};
 use qwt::RSQVector256;
-
 // traits
 use qwt::{AccessQuad, RankQuad, SelectQuad};
 

--- a/examples/perf_rs_wide.rs
+++ b/examples/perf_rs_wide.rs
@@ -1,9 +1,7 @@
 use mem_dbg::{MemSize, SizeFlags};
-use qwt::{
-    bitvector::wide::RS,
-    perf_and_test_utils::{gen_queries, type_of, TimingQueries},
-    AccessBin, RankBin, SelectBin,
-};
+use qwt::bitvector::wide::RS;
+use qwt::perf_and_test_utils::{gen_queries, type_of, TimingQueries};
+use qwt::{AccessBin, RankBin, SelectBin};
 
 const N_RUNS: usize = 5;
 const N_QUERIES: usize = 10_000_000;

--- a/examples/perf_wavelet_tree.rs
+++ b/examples/perf_wavelet_tree.rs
@@ -1,19 +1,18 @@
-use std::{fs, path::Path};
-
 use clap::Parser;
 use mem_dbg::{MemSize, SizeFlags};
+use qwt::perf_and_test_utils::{
+    gen_queries, gen_rank_queries, gen_select_queries, random_range_queries, type_of, TimingQueries,
+};
+use qwt::quadwt::RSforWT;
+use qwt::utils::{msb, text_remap};
 use qwt::{
-    perf_and_test_utils::{
-        gen_queries, gen_rank_queries, gen_select_queries, random_range_queries, type_of,
-        TimingQueries,
-    },
-    quadwt::RSforWT,
-    utils::{msb, text_remap},
     AccessUnsigned, HQWT256Pfs, HQWT512Pfs, HuffQWaveletTree, OccsRangeUnsigned, QWT256Pfs,
     QWT512Pfs, QWaveletTree, RankUnsigned, SelectUnsigned, HQWT256, HQWT512, HWT, QWT256, QWT512,
     WT,
 };
 use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
 
 const N_RUNS: usize = 10;
 

--- a/src/binwt/mod.rs
+++ b/src/binwt/mod.rs
@@ -169,9 +169,7 @@ where
         let mut bvs = Vec::with_capacity(n_levels);
         let mut lens = Vec::with_capacity(n_levels);
 
-        let mut shift = 1;
-
-        for _level in 0..n_levels {
+        for shift in 1..=n_levels {
             let mut cur_bv = BitVectorMut::new();
 
             for &s in sequence.iter() {
@@ -180,12 +178,12 @@ where
                         "some error occurred during code translation while building huffqwt",
                     );
 
-                    if cur_code.len >= shift {
-                        let symbol = ((cur_code.content >> (cur_code.len - shift)) & 1) == 1;
+                    if cur_code.len >= shift as u32 {
+                        let symbol = ((cur_code.content >> (cur_code.len - shift as u32)) & 1) == 1;
                         cur_bv.push(symbol);
                     }
                 } else {
-                    let symbol = ((s >> (n_levels - shift as usize)).as_() & 1) == 1;
+                    let symbol = ((s >> (n_levels - shift)).as_() & 1) == 1;
                     cur_bv.push(symbol);
                 }
             }
@@ -196,16 +194,10 @@ where
             bvs.push(BRS::from(bv));
 
             if COMPRESSED {
-                stable_partition_of_2_with_codes(
-                    sequence,
-                    shift as usize,
-                    codes_encode.as_ref().unwrap(),
-                );
+                stable_partition_of_2_with_codes(sequence, shift, codes_encode.as_ref().unwrap());
             } else {
-                stable_partition_of_2(sequence, n_levels - shift as usize);
+                stable_partition_of_2(sequence, n_levels - shift);
             }
-
-            shift += 1;
         }
 
         bvs.shrink_to_fit();

--- a/src/binwt/mod.rs
+++ b/src/binwt/mod.rs
@@ -1,20 +1,16 @@
-use std::{
-    collections::HashMap,
-    marker::PhantomData,
-    ops::{Bound, Range, RangeBounds},
+use crate::quadwt::huffqwt::PrefixCode;
+use crate::utils::{msb, stable_partition_of_2, stable_partition_of_2_with_codes};
+use crate::{
+    AccessUnsigned, BinWTSupport, BitVector, BitVectorMut, OccsRangeUnsigned, RankUnsigned,
+    SelectUnsigned, WTIndexable, WTIterator,
 };
-
 use mem_dbg::{MemDbg, MemSize};
 use minimum_redundancy::{BitsPerFragment, Coding};
 use num_traits::AsPrimitive;
 use serde::{Deserialize, Serialize};
-
-use crate::{
-    quadwt::huffqwt::PrefixCode,
-    utils::{msb, stable_partition_of_2, stable_partition_of_2_with_codes},
-    AccessUnsigned, BinWTSupport, BitVector, BitVectorMut, OccsRangeUnsigned, RankUnsigned,
-    SelectUnsigned, WTIndexable, WTIterator,
-};
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::ops::{Bound, Range, RangeBounds};
 
 pub trait BinRSforWT: From<BitVector> + BinWTSupport + MemSize + MemDbg + Default {}
 impl<T> BinRSforWT for T where T: From<BitVector> + BinWTSupport + MemSize + MemDbg + Default {}
@@ -31,7 +27,7 @@ pub struct WaveletTree<T, BRS, const COMPRESSED: bool = false> {
     phantom_data: PhantomData<T>,
 }
 
-struct LenInfo(usize, u32); //symbol, len
+struct LenInfo(usize, u32); // symbol, len
 
 #[allow(clippy::identity_op)]
 fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCode> {
@@ -47,7 +43,7 @@ fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCod
 
     let mut c = vec![0; alph_size];
     let mut assignments = vec![PrefixCode { content: 0, len: 0 }; sigma + 1];
-    let mut m = 1; //how many codes we have so far
+    let mut m = 1; // how many codes we have so far
     let mut l = 0;
 
     for j in 0..alph_size {
@@ -62,8 +58,8 @@ fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCod
             l += 1;
         }
 
-        //the codes are stored in lexicographic order of their reverse codes,
-        //now we get the actual one we need by reversing it
+        // the codes are stored in lexicographic order of their reverse codes,
+        // now we get the actual one we need by reversing it
         let mut reversed_code = 0;
         for t in 0..l {
             reversed_code |= ((c[j] >> t) & 1) << (l - t - 1);
@@ -128,9 +124,9 @@ where
         let sigma = *sequence.iter().max().unwrap();
 
         if COMPRESSED {
-            //we craft the codes
+            // we craft the codes
 
-            //count symbol frequences
+            // count symbol frequences
             let freqs = sequence.iter().fold(HashMap::new(), |mut map, &c| {
                 *map.entry(c.as_()).or_insert(0u32) += 1;
                 map
@@ -155,7 +151,7 @@ where
                 }
             }
 
-            //sort codes to make it easier to search
+            // sort codes to make it easier to search
             for v in decoder.iter_mut() {
                 v.sort_by_key(|(x, _)| *x)
             }
@@ -169,7 +165,7 @@ where
             sig = Some(sigma);
         }
 
-        //populate bvs
+        // populate bvs
         let mut bvs = Vec::with_capacity(n_levels);
         let mut lens = Vec::with_capacity(n_levels);
 
@@ -266,7 +262,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{WT, HWT};
+    /// use qwt::{HWT, WT};
     ///
     /// let data = vec![1u8, 0, 1, 0, 255, 4, 5, 3];
     ///
@@ -294,7 +290,10 @@ where
     ///
     /// assert_eq!(wt.iter().collect::<Vec<_>>(), data);
     ///
-    /// assert_eq!(wt.iter().rev().collect::<Vec<_>>(), data.into_iter().rev().collect::<Vec<_>>());
+    /// assert_eq!(
+    ///     wt.iter().rev().collect::<Vec<_>>(),
+    ///     data.into_iter().rev().collect::<Vec<_>>()
+    /// );
     /// ```
     pub fn iter(
         &self,

--- a/src/binwt/tests.rs
+++ b/src/binwt/tests.rs
@@ -49,8 +49,12 @@ fn test_occs_range() {
     assert!(wt.occs_range(data.len() - 1..data.len() + 1).is_none());
 
     // nonsense ranges
-    assert!(wt.occs_range(5..4).is_none());
-    assert!(wt.occs_range(2..0).is_none());
+    assert!(wt
+        .occs_range(std::ops::Range { start: 5, end: 4 })
+        .is_none());
+    assert!(wt
+        .occs_range(std::ops::Range { start: 2, end: 0 })
+        .is_none());
 
     // empty ranges
     assert_eq!(0, wt.occs_range(data.len()..).unwrap().count());
@@ -92,8 +96,12 @@ fn test_occs_range_compressed() {
     assert!(wt.occs_range(data.len() - 1..data.len() + 1).is_none());
 
     // nonsense ranges
-    assert!(wt.occs_range(5..4).is_none());
-    assert!(wt.occs_range(2..0).is_none());
+    assert!(wt
+        .occs_range(std::ops::Range { start: 5, end: 4 })
+        .is_none());
+    assert!(wt
+        .occs_range(std::ops::Range { start: 2, end: 0 })
+        .is_none());
 
     // empty ranges
     assert_eq!(0, wt.occs_range(data.len()..).unwrap().count());

--- a/src/bitvector/mod.rs
+++ b/src/bitvector/mod.rs
@@ -5,7 +5,6 @@
 //! The immutable bit vector allows access to bits and can be extended to support [`RankBin`] and [`SelectBin`] queries.
 //!
 //! For both data structures, it is possible to iterate over bits or positions of bits set either to zero or one.
-
 use crate::utils::{prefetch_read_NTA, select_in_word};
 use crate::{AccessBin, RankBin, SelectBin};
 use mem_dbg::{MemDbg, MemSize};
@@ -466,7 +465,6 @@ impl AccessBin for BitVector {
     /// assert_eq!(bv.get(1), Some(false));
     /// assert_eq!(bv.get(10), None);
     /// ```
-
     #[inline(always)]
     fn get(&self, index: usize) -> Option<bool> {
         if index >= self.len() {
@@ -489,7 +487,6 @@ impl AccessBin for BitVector {
     ///
     /// assert_eq!(unsafe { bv.get_unchecked(5) }, true);
     /// ```
-
     #[inline(always)]
     unsafe fn get_unchecked(&self, index: usize) -> bool {
         BitVectorMut::get_bit_slice(cast_to_u64_slice(&self.data), index)
@@ -1115,7 +1112,7 @@ impl BitVectorMut {
         let shift = index & 63;
 
         let mask = if len == 64 {
-            std::u64::MAX
+            u64::MAX
         } else {
             (1_u64 << len) - 1
         };
@@ -1171,7 +1168,7 @@ impl BitVectorMut {
         self.count_ones += bits.count_ones() as usize;
 
         // let mask = if len == 64 {
-        //     std::u64::MAX
+        //     u64::MAX
         // } else {
         //     (1_u64 << len) - 1
         // };
@@ -1404,7 +1401,6 @@ impl AccessBin for BitVectorMut {
     /// assert_eq!(bv.get(8), Some(false));
     /// assert_eq!(bv.get(10), None);
     /// ```
-
     #[inline(always)]
     fn get(&self, index: usize) -> Option<bool> {
         if index >= self.len() {
@@ -1426,7 +1422,6 @@ impl AccessBin for BitVectorMut {
     /// bv.extend_with_zeros(10);
     /// assert_eq!(unsafe { bv.get_unchecked(8) }, false);
     /// ```
-
     #[inline(always)]
     unsafe fn get_unchecked(&self, index: usize) -> bool {
         Self::get_bit_slice(cast_to_u64_slice(&self.data), index)

--- a/src/bitvector/mod.rs
+++ b/src/bitvector/mod.rs
@@ -6,11 +6,8 @@
 //!
 //! For both data structures, it is possible to iterate over bits or positions of bits set either to zero or one.
 
-use crate::{
-    utils::{prefetch_read_NTA, select_in_word},
-    AccessBin, RankBin, SelectBin,
-};
-
+use crate::utils::{prefetch_read_NTA, select_in_word};
+use crate::{AccessBin, RankBin, SelectBin};
 use mem_dbg::{MemDbg, MemSize};
 use serde::{Deserialize, Serialize};
 
@@ -24,14 +21,14 @@ struct DataLine {
 }
 
 impl DataLine {
-    //set symbol to position `i`
+    // set symbol to position `i`
     #[inline]
     fn set_symbol(&mut self, symbol: u64, i: usize) {
         assert!(i < 512);
 
         let mask: u64 = 1 << (i % 64);
-        self.words[i >> 6] ^= self.words[i >> 6] & mask; //zero out the position
-        self.words[i >> 6] ^= (symbol & 1) << (i % 64); //set position to symbol
+        self.words[i >> 6] ^= self.words[i >> 6] & mask; // zero out the position
+        self.words[i >> 6] ^= (symbol & 1) << (i % 64); // set position to symbol
     }
 
     #[inline]
@@ -107,7 +104,7 @@ impl RankBin for DataLine {
 }
 
 fn cast_to_u64_slice(data_lines: &[DataLine]) -> &[u64] {
-    //WARNING: this works because DataLine is aligned
+    // WARNING: this works because DataLine is aligned
     unsafe {
         let len = data_lines.len().checked_mul(8).unwrap();
         let ptr = data_lines.as_ptr();
@@ -128,7 +125,7 @@ impl SelectBin for DataLine {
     #[inline(always)]
     unsafe fn select1_unchecked(&self, i: usize) -> usize {
         let mut off = 0;
-        let mut rank = 0; //rank so far
+        let mut rank = 0; // rank so far
 
         for w in 0..8 {
             let kp = self.words.get_unchecked(w).count_ones();
@@ -188,9 +185,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use qwt::{BitVector, AccessBin};
+    /// use qwt::{AccessBin, BitVector};
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     /// assert_eq!(bv.get(1), Some(false));
     ///
@@ -226,9 +223,9 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use qwt::{BitVector};
+    /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// // This is unsafe because it does not perform bounds checking
@@ -249,7 +246,7 @@ impl BitVector {
     /// ```
     /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// // Get the 64-bit word at index 0
@@ -269,12 +266,12 @@ impl BitVector {
     /// ```
     /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,4,5,64,129];
+    /// let v = vec![0, 2, 3, 4, 5, 64, 129];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// // Get all 64-bit words
     /// let words = bv.words();
-    /// assert_eq!(words, [0b111101,0b1,0b10]);
+    /// assert_eq!(words, [0b111101, 0b1, 0b10]);
     /// ```
     #[must_use]
     #[inline]
@@ -291,7 +288,6 @@ impl BitVector {
     ///
     /// let vv: Vec<usize> = vec![0, 63, 128, 129, 254, 1026];
     /// let bv: BitVector = vv.iter().copied().collect();
-    ///
     /// ```
     #[must_use]
     pub fn ones(&self) -> BitVectorBitPositionsIter<'_, true> {
@@ -321,8 +317,8 @@ impl BitVector {
     /// # Examples
     ///
     /// ```
-    /// use qwt::BitVector;
     /// use qwt::perf_and_test_utils::negate_vector;
+    /// use qwt::BitVector;
     ///
     /// let vv: Vec<usize> = vec![0, 63, 128, 129, 254, 1026];
     /// let bv: BitVector = vv.iter().copied().collect();
@@ -348,7 +344,7 @@ impl BitVector {
     /// ```
     /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,5];
+    /// let v = vec![0, 2, 3, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// let mut iter = bv.iter();
@@ -379,7 +375,7 @@ impl BitVector {
     /// ```
     /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// assert!(!bv.is_empty());
@@ -400,7 +396,7 @@ impl BitVector {
     /// ```
     /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// assert_eq!(bv.len(), 6);
@@ -416,7 +412,7 @@ impl BitVector {
     /// ```
     /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// assert_eq!(bv.count_ones(), 5);
@@ -432,7 +428,7 @@ impl BitVector {
     /// ```
     /// use qwt::BitVector;
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// assert_eq!(bv.count_zeros(), 1);
@@ -461,9 +457,9 @@ impl AccessBin for BitVector {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{BitVector, AccessBin};
+    /// use qwt::{AccessBin, BitVector};
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
     /// assert_eq!(bv.get(5), Some(true));
@@ -486,12 +482,12 @@ impl AccessBin for BitVector {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{BitVector, AccessBin};
+    /// use qwt::{AccessBin, BitVector};
     ///
-    /// let v = vec![0,2,3,4,5];
+    /// let v = vec![0, 2, 3, 4, 5];
     /// let bv: BitVector = v.into_iter().collect();
     ///
-    /// assert_eq!(unsafe{bv.get_unchecked(5)}, true);
+    /// assert_eq!(unsafe { bv.get_unchecked(5) }, true);
     /// ```
 
     #[inline(always)]
@@ -580,7 +576,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use qwt::{BitVector, BitVectorMut, AccessBin};
+/// use qwt::{AccessBin, BitVector, BitVectorMut};
 ///
 /// let mut bvm = BitVectorMut::new();
 /// bvm.push(true);
@@ -608,9 +604,9 @@ impl From<BitVectorMut> for BitVector {
 /// # Examples
 ///
 /// ```
-/// use qwt::{BitVector, BitVectorMut, AccessBin};
+/// use qwt::{AccessBin, BitVector, BitVectorMut};
 ///
-/// let v = vec![0,2,3,4,5];
+/// let v = vec![0, 2, 3, 4, 5];
 /// let mut bv: BitVector = v.into_iter().collect();
 ///
 /// // Convert immutable BitVector to mutable BitVectorMut
@@ -879,10 +875,10 @@ impl BitVectorMut {
     /// # Examples
     ///
     /// ```
-    /// use qwt::{BitVectorMut, BitVector};
+    /// use qwt::{BitVector, BitVectorMut};
     ///
     /// let v = [0b1110];
-    /// let bv: BitVector = BitVectorMut::from_packed_data(&v,4).into();
+    /// let bv: BitVector = BitVectorMut::from_packed_data(&v, 4).into();
     /// assert_eq!(bv.words()[0], 0b1110);
     /// ```
     #[must_use]
@@ -909,7 +905,7 @@ impl BitVectorMut {
     /// # Example
     ///
     /// ```
-    /// use qwt::{BitVectorMut, AccessBin};
+    /// use qwt::{AccessBin, BitVectorMut};
     ///
     /// let mut bv = BitVectorMut::new();
     /// bv.push(true);
@@ -952,10 +948,9 @@ impl BitVectorMut {
     /// use qwt::BitVectorMut;
     ///
     /// let mut bv = BitVectorMut::with_capacity(7);
-    /// bv.append_bits(0b101, 3);  // appends 101
-    /// bv.append_bits(0b0110, 4); // appends 0110  
+    /// bv.append_bits(0b101, 3); // appends 101
+    /// bv.append_bits(0b0110, 4); // appends 0110
     ///
-    ///         
     /// assert_eq!(bv.len(), 7);
     /// assert_eq!(bv.get_bits(0, 3), Some(5));
     /// ```
@@ -996,7 +991,7 @@ impl BitVectorMut {
     /// # Examples
     ///
     /// ```
-    /// use qwt::{BitVectorMut, AccessBin};
+    /// use qwt::{AccessBin, BitVectorMut};
     ///
     /// let mut bv = BitVectorMut::with_capacity(10);
     /// bv.extend_with_zeros(10);
@@ -1019,7 +1014,7 @@ impl BitVectorMut {
     /// # Examples
     ///
     /// ```
-    /// use qwt::{BitVectorMut, AccessBin};
+    /// use qwt::{AccessBin, BitVectorMut};
     ///
     /// let mut bv = BitVectorMut::with_capacity(2);
     /// bv.push(true);
@@ -1058,7 +1053,7 @@ impl BitVectorMut {
     /// # Examples
     ///
     /// ```
-    /// use qwt::{BitVectorMut, AccessBin};
+    /// use qwt::{AccessBin, BitVectorMut};
     ///
     /// let mut bv = BitVectorMut::with_capacity(6);
     /// bv.append_bits(0b111101, 6); // Appends 111101 note that we append bits from right to left
@@ -1258,8 +1253,8 @@ impl BitVectorMut {
     /// # Examples
     ///
     /// ```
-    /// use qwt::BitVectorMut;
     /// use qwt::perf_and_test_utils::negate_vector;
+    /// use qwt::BitVectorMut;
     ///
     /// let vv: Vec<usize> = vec![0, 63, 128, 129, 254, 1026];
     /// let bv: BitVectorMut = vv.iter().copied().collect();
@@ -1402,7 +1397,7 @@ impl AccessBin for BitVectorMut {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{BitVectorMut, AccessBin};
+    /// use qwt::{AccessBin, BitVectorMut};
     ///
     /// let mut bv = BitVectorMut::with_capacity(10);
     /// bv.extend_with_zeros(10);
@@ -1425,11 +1420,11 @@ impl AccessBin for BitVectorMut {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{BitVectorMut, AccessBin};
+    /// use qwt::{AccessBin, BitVectorMut};
     ///
     /// let mut bv = BitVectorMut::with_capacity(10);
     /// bv.extend_with_zeros(10);
-    /// assert_eq!(unsafe{bv.get_unchecked(8)}, false);
+    /// assert_eq!(unsafe { bv.get_unchecked(8) }, false);
     /// ```
 
     #[inline(always)]
@@ -1448,14 +1443,13 @@ impl Extend<bool> for BitVectorMut {
         }
     }
 
-    /* Nigthly
-        fn extend_one(&mut self, item: bool) {
-            self.push(item);
-        }
-        fn extend_reserve(&mut self, additional: usize) {
-            self.data.reserve
-        }
-    */
+    // Nigthly
+    // fn extend_one(&mut self, item: bool) {
+    // self.push(item);
+    // }
+    // fn extend_reserve(&mut self, additional: usize) {
+    // self.data.reserve
+    // }
 }
 
 /// Implements creating a `BitVectorMut` from an iterator over `bool` values.
@@ -1513,7 +1507,7 @@ impl FromIterator<usize> for BitVectorMut {
 /// # Examples
 ///
 /// ```
-/// use qwt::{BitVectorMut, AccessBin};
+/// use qwt::{AccessBin, BitVectorMut};
 ///
 /// let mut bv = BitVectorMut::new();
 ///

--- a/src/bitvector/narrow.rs
+++ b/src/bitvector/narrow.rs
@@ -3,15 +3,12 @@
 //!
 //! This implementation is inspired by the C++ implementation by [Giuseppe Ottaviano](https://github.com/ot/succinct/blob/master/rs_bit_vector.cpp).
 
-use crate::{
-    utils::{prefetch_read_NTA, select_in_word},
-    AccessBin, BitVector, RankBin, SelectBin,
-};
-
+use crate::utils::{prefetch_read_NTA, select_in_word};
+use crate::{AccessBin, BitVector, RankBin, SelectBin};
 use mem_dbg::{MemDbg, MemSize};
 use serde::{Deserialize, Serialize};
 
-//block_rank_pairs layout
+// block_rank_pairs layout
 //|superblock0|block0|superblock1|block1...
 const BLOCK_SIZE: usize = 8; // in 64bit words
 
@@ -59,7 +56,7 @@ impl RS {
                 next_rank += word_pop;
                 cur_subrank += word_pop;
 
-                //check for samples
+                // check for samples
                 if next_rank / SELECT_ONES_PER_HINT as u64 > cur_hint_1 {
                     select_samples[1].push(b);
                     cur_hint_1 += 1;
@@ -174,7 +171,7 @@ impl RS {
         // rank = self.block_rank(position);
         // println!("selected block {} with rank {}", position, rank);
 
-        //now we examine sub_blocks
+        // now we examine sub_blocks
         position *= BLOCK_SIZE;
 
         // println!("now sub_blocks");
@@ -217,7 +214,7 @@ impl RS {
         // rank = position * max_rank_for_block - self.block_rank(position);
         // println!("selected block {} with rank0 {}", position, position * max_rank_for_block - self.block_rank(position));
 
-        //now we examine sub_blocks
+        // now we examine sub_blocks
         position *= BLOCK_SIZE;
 
         let max_rank_for_subblock = 64;

--- a/src/bitvector/narrow.rs
+++ b/src/bitvector/narrow.rs
@@ -111,6 +111,12 @@ impl RS {
         self.bv.len()
     }
 
+    /// Returns true if the bitvector is empty.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.bv.len() == 0
+    }
+
     /// Returns a reference to the underlying bitvector.
     #[inline]
     pub fn bit_vector(&self) -> &BitVector {

--- a/src/bitvector/tests.rs
+++ b/src/bitvector/tests.rs
@@ -76,8 +76,8 @@ fn test_from_iter() {
 
     assert_eq!(bv, bv2);
 
-    /* Note: if last bits are zero, the bit vector may differ
-    because we are inserting only position of ones */
+    // Note: if last bits are zero, the bit vector may differ
+    // because we are inserting only position of ones
     let bv2: BitVectorMut = (0..n).filter(|x| x % 2 == 0).collect();
 
     assert_eq!(bv, bv2);

--- a/src/bitvector/wide.rs
+++ b/src/bitvector/wide.rs
@@ -140,6 +140,12 @@ impl RS {
         self.bv.len()
     }
 
+    /// Returns true if the bitvector is empty.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.bv.len() == 0
+    }
+
     /// Returns a reference to the underlying bitvector.
     #[inline]
     pub fn bit_vector(&self) -> &BitVector {

--- a/src/bitvector/wide.rs
+++ b/src/bitvector/wide.rs
@@ -1,12 +1,12 @@
 //! Implements data structure to support `rank` and `select` queries on a binary vector with 512-bit blocks.
 //!
 //! This implementation is inspired by [this paper by Florian Kurpicz] (https://link.springer.com/chapter/10.1007/978-3-031-20643-6_19)
-use crate::{utils::prefetch_read_NTA, AccessBin, BitVector, RankBin, SelectBin};
-
+use crate::utils::prefetch_read_NTA;
+use crate::{AccessBin, BitVector, RankBin, SelectBin};
 use mem_dbg::{MemDbg, MemSize};
 use serde::{Deserialize, Serialize};
 
-//superblock is 44 bits, blocks are (BLOCK_SIZE-1) * 12 bits each
+// superblock is 44 bits, blocks are (BLOCK_SIZE-1) * 12 bits each
 const BLOCK_SIZE: usize = 8; // 8 64bit words for each block
 const SUPERBLOCK_SIZE: usize = 8 * BLOCK_SIZE; // 8 blocks for each superblock (this is the size in u64 words)
 
@@ -16,7 +16,7 @@ const SELECT_ZEROS_PER_HINT: usize = SELECT_ONES_PER_HINT;
 #[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize, MemSize, MemDbg, Debug)]
 pub struct RS {
     bv: BitVector,
-    superblock_metadata: Box<[u128]>, // in each u128 we store the pair (superblock, <7 blocks>) like so |L1  |L2|L2|L2|L2|L2|L2|L2|
+    superblock_metadata: Box<[u128]>, /* in each u128 we store the pair (superblock, <7 blocks>) like so |L1  |L2|L2|L2|L2|L2|L2|L2| */
     select_samples: [Box<[usize]>; 2],
     count_zeros: usize,
 }
@@ -38,7 +38,7 @@ impl RS {
 
         for (b, &dl) in bv.data.iter().enumerate() {
             if b % 8 == 0 {
-                //we are at the start of new superblock, so we push the rank so far
+                // we are at the start of new superblock, so we push the rank so far
                 total_rank += word_pop;
                 word_pop = 0;
 
@@ -47,8 +47,8 @@ impl RS {
                 // println!("new superblock! added metadata, total rank: {}", total_rank);
                 // println!("metadata so far: {:0>128b}", cur_metadata);
             } else {
-                //we ignore the frist block beacuse it would be 0
-                //if we are not at the start of a new superblock, we are at the start of a block
+                // we ignore the frist block beacuse it would be 0
+                // if we are not at the start of a new superblock, we are at the start of a block
                 cur_metadata <<= 12;
                 cur_metadata |= word_pop;
 
@@ -59,26 +59,26 @@ impl RS {
             word_pop += dl.count_ones() as u128;
 
             if (total_rank + word_pop) / SELECT_ONES_PER_HINT as u128 > cur_hint_1 {
-                //we insert a new hint for 1
+                // we insert a new hint for 1
                 select_samples[1].push(b / 8);
                 cur_hint_1 += 1;
             }
 
             zeros_so_far += dl.count_zeros() as u128;
             if (zeros_so_far / SELECT_ZEROS_PER_HINT as u128) > cur_hint_0 {
-                //we insert a new hint for 0
+                // we insert a new hint for 0
                 select_samples[0].push(b / 8);
                 cur_hint_0 += 1;
             }
 
             if (b + 1) % 8 == 0 {
-                //next round we reset the metadata so we push it now
+                // next round we reset the metadata so we push it now
                 superblock_metadata.push(cur_metadata);
                 // println!("Pushed superblock!");
             }
         }
 
-        //we flush the remainder in total rank
+        // we flush the remainder in total rank
         total_rank += word_pop;
 
         let left: usize = bv.data.len() % 8;
@@ -94,7 +94,7 @@ impl RS {
             // println!("Pushed superblock!");
         }
 
-        //we push last superblock containing only the last total_rank
+        // we push last superblock containing only the last total_rank
         cur_metadata = 0;
         cur_metadata |= total_rank;
         cur_metadata <<= 128 - 44;
@@ -103,7 +103,7 @@ impl RS {
 
         superblock_metadata.shrink_to_fit();
 
-        //guard at the end
+        // guard at the end
         select_samples[0].push(superblock_metadata.len() - 1);
         select_samples[1].push(superblock_metadata.len() - 1);
 
@@ -163,7 +163,7 @@ impl RS {
         self.bv.prefetch_line(pos / 512);
     }
 
-    ///returns the total rank1 up to `sub_block`
+    /// returns the total rank1 up to `sub_block`
     #[inline(always)]
     fn sub_block_rank(&self, sub_block: usize) -> usize {
         let mut result = 0;
@@ -199,7 +199,7 @@ impl RS {
         position = hint_start - 1;
         // println!("selected superblock {} with rank {}", position, self.superblock_rank(position););
 
-        //now we examine sub_blocks
+        // now we examine sub_blocks
         position *= SUPERBLOCK_SIZE / BLOCK_SIZE;
 
         // println!("now sub_blocks");
@@ -209,7 +209,7 @@ impl RS {
                 position += j - 1;
                 break;
             }
-            //if we didn't stop before
+            // if we didn't stop before
             if j == 7 {
                 position += j;
             }
@@ -242,7 +242,7 @@ impl RS {
         position = hint_start - 1;
         // println!("selected block {} with rank0 {}", position, position * max_rank_for_block - self.superblock_rank(position));
 
-        //now we examine sub_blocks
+        // now we examine sub_blocks
         position *= SUPERBLOCK_SIZE / BLOCK_SIZE;
 
         let max_rank_for_subblock = BLOCK_SIZE * 64;
@@ -335,8 +335,8 @@ impl SelectBin for RS {
     /// Returns `None` if the data structure has no such element (i >= maximum rank1)
     /// # Examples
     /// ```
-    /// use qwt::{BitVector, wide::RS, SelectBin};
-    ///
+    /// use qwt::wide::RS;
+    /// use qwt::{BitVector, SelectBin};
     ///
     /// let vv: Vec<usize> = vec![3, 5, 8, 128, 129, 513, 1000, 1024, 1025];
     /// let bv: BitVector = vv.iter().copied().collect();
@@ -350,7 +350,6 @@ impl SelectBin for RS {
     /// assert_eq!(rs.select1(5), Some(513));
     /// assert_eq!(rs.select1(8), Some(1025));
     /// assert_eq!(rs.select1(9), None);
-    ///
     /// ```
     fn select1(&self, i: usize) -> Option<usize> {
         if i >= self.count_ones() {
@@ -380,8 +379,9 @@ impl SelectBin for RS {
     /// Returns `None` if the data structure has no such element (i >= maximum rank0)
     /// # Examples
     /// ```
-    /// use qwt::{BitVector, wide::RS, SelectBin};
     /// use qwt::perf_and_test_utils::negate_vector;
+    /// use qwt::wide::RS;
+    /// use qwt::{BitVector, SelectBin};
     ///
     /// let vv: Vec<usize> = vec![3, 5, 8, 128, 129, 513, 1000, 1024, 1025];
     /// let bv: BitVector = vv.iter().copied().collect();
@@ -396,7 +396,6 @@ impl SelectBin for RS {
     /// assert_eq!(rs.select0(125), Some(130));
     /// assert_eq!(rs.select0(1016), Some(1023));
     /// assert_eq!(rs.select0(1017), None);
-    ///
     /// ```
     fn select0(&self, i: usize) -> Option<usize> {
         if i >= self.count_zeros() {

--- a/src/bytes/error.rs
+++ b/src/bytes/error.rs
@@ -27,11 +27,16 @@ pub enum LayoutError {
 impl fmt::Display for LayoutError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::NotLittleEndian => write!(f, "host is not little-endian (QWTB/HQWB v1 requires LE)"),
+            Self::NotLittleEndian => {
+                write!(f, "host is not little-endian (QWTB/HQWB v1 requires LE)")
+            }
             Self::BadMagic => write!(f, "bad magic (expected QWTB or HQWB)"),
             Self::BadVersion => write!(f, "unsupported format version"),
             Self::Truncated => write!(f, "truncated byte blob"),
-            Self::Misaligned => write!(f, "misaligned offset (need 64-byte alignment for POD arrays)"),
+            Self::Misaligned => write!(
+                f,
+                "misaligned offset (need 64-byte alignment for POD arrays)"
+            ),
             Self::PrefetchNotSupported => {
                 write!(f, "prefetch-augmented trees are not supported in v1")
             }

--- a/src/bytes/error.rs
+++ b/src/bytes/error.rs
@@ -1,0 +1,43 @@
+//! Errors for the zero-copy byte I/O layer.
+
+use std::fmt;
+
+/// Errors produced while encoding or decoding a `QWTB` / `HQWB` blob.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LayoutError {
+    /// Host endianness is not little-endian. The v1 format is LE-only.
+    NotLittleEndian,
+    /// Magic bytes do not match `QWTB` / `HQWB`.
+    BadMagic,
+    /// Unsupported or unknown format version.
+    BadVersion,
+    /// Byte slice is shorter than the header / directory / payload requires.
+    Truncated,
+    /// A required offset is not properly aligned (POD arrays need 64-byte alignment).
+    Misaligned,
+    /// Prefetch-augmented trees (`*Pfs`) are not supported in v1.
+    PrefetchNotSupported,
+    /// Structural inconsistency (e.g. `n_levels` disagrees with payload counts).
+    Inconsistent {
+        /// Human-readable detail.
+        detail: &'static str,
+    },
+}
+
+impl fmt::Display for LayoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotLittleEndian => write!(f, "host is not little-endian (QWTB/HQWB v1 requires LE)"),
+            Self::BadMagic => write!(f, "bad magic (expected QWTB or HQWB)"),
+            Self::BadVersion => write!(f, "unsupported format version"),
+            Self::Truncated => write!(f, "truncated byte blob"),
+            Self::Misaligned => write!(f, "misaligned offset (need 64-byte alignment for POD arrays)"),
+            Self::PrefetchNotSupported => {
+                write!(f, "prefetch-augmented trees are not supported in v1")
+            }
+            Self::Inconsistent { detail } => write!(f, "inconsistent layout: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for LayoutError {}

--- a/src/bytes/from_parts_tests.rs
+++ b/src/bytes/from_parts_tests.rs
@@ -3,9 +3,8 @@
 use crate::qvector::rs_qvector::{RSQVector256, RSSupportPlain};
 use crate::qvector::{DataLine, QVector};
 use crate::{
-    AccessQuad, AccessUnsigned, HQWT256, QWT256, RankUnsigned, SelectUnsigned, SuperblockPlain,
+    AccessQuad, AccessUnsigned, RankUnsigned, SelectUnsigned, SuperblockPlain, HQWT256, QWT256,
 };
-
 
 #[test]
 fn qvector_from_raw_parts_eq() {
@@ -29,9 +28,8 @@ fn rsqvector_from_parts_eq() {
     );
     let rs = original.rs_support();
     let superblocks: Box<[SuperblockPlain]> = rs.superblocks().to_vec().into_boxed_slice();
-    let select_samples: [Box<[u32]>; 4] = std::array::from_fn(|s| {
-        rs.select_samples(s).to_vec().into_boxed_slice()
-    });
+    let select_samples: [Box<[u32]>; 4] =
+        std::array::from_fn(|s| rs.select_samples(s).to_vec().into_boxed_slice());
     let rs_rebuilt = RSSupportPlain::<256>::from_parts(superblocks, select_samples);
     let rebuilt = RSQVector256::from_parts(qv, rs_rebuilt, original.n_occs_smaller());
     assert_eq!(original, rebuilt);
@@ -52,9 +50,8 @@ fn qwt_from_parts_eq_queries() {
             );
             let support = rs.rs_support();
             let superblocks = support.superblocks().to_vec().into_boxed_slice();
-            let select_samples = std::array::from_fn(|s| {
-                support.select_samples(s).to_vec().into_boxed_slice()
-            });
+            let select_samples =
+                std::array::from_fn(|s| support.select_samples(s).to_vec().into_boxed_slice());
             let rs_support = RSSupportPlain::<256>::from_parts(superblocks, select_samples);
             RSQVector256::from_parts(qv, rs_support, rs.n_occs_smaller())
         })
@@ -117,9 +114,8 @@ fn hqwt_from_parts_eq_queries() {
             );
             let support = rs.rs_support();
             let superblocks = support.superblocks().to_vec().into_boxed_slice();
-            let select_samples = std::array::from_fn(|s| {
-                support.select_samples(s).to_vec().into_boxed_slice()
-            });
+            let select_samples =
+                std::array::from_fn(|s| support.select_samples(s).to_vec().into_boxed_slice());
             let rs_support = RSSupportPlain::<256>::from_parts(superblocks, select_samples);
             RSQVector256::from_parts(qv, rs_support, rs.n_occs_smaller())
         })

--- a/src/bytes/from_parts_tests.rs
+++ b/src/bytes/from_parts_tests.rs
@@ -60,7 +60,14 @@ fn qwt_from_parts_eq_queries() {
         })
         .collect();
 
-    let rebuilt = QWT256::from_parts(original.len(), original.sigma_raw(), levels).unwrap();
+    let rebuilt = QWT256::from_parts(
+        original.len(),
+        original.n_levels(),
+        original.sigma_raw(),
+        levels,
+    )
+    .unwrap();
+
     assert_eq!(original.len(), rebuilt.len());
     assert_eq!(original.n_levels(), rebuilt.n_levels());
     for i in 0..data.len() {
@@ -146,6 +153,7 @@ fn hqwt_from_parts_eq_queries() {
 #[test]
 fn qwt_pfs_from_parts_rejected() {
     use crate::QWT256Pfs;
-    let err = QWT256Pfs::<u32>::from_parts(0, 0, vec![]).unwrap_err();
+    let err = QWT256Pfs::<u32>::from_parts(0, 0, 0, vec![]).unwrap_err();
+
     assert_eq!(err, crate::bytes::LayoutError::PrefetchNotSupported);
 }

--- a/src/bytes/from_parts_tests.rs
+++ b/src/bytes/from_parts_tests.rs
@@ -1,0 +1,151 @@
+//! Tests for raw-parts constructors (disassemble → reassemble).
+
+use crate::qvector::rs_qvector::{RSQVector256, RSSupportPlain};
+use crate::qvector::{DataLine, QVector};
+use crate::{
+    AccessQuad, AccessUnsigned, HQWT256, QWT256, RankUnsigned, SelectUnsigned, SuperblockPlain,
+};
+
+
+#[test]
+fn qvector_from_raw_parts_eq() {
+    let original: QVector = (0..1000u32).map(|x| (x % 4) as u8).collect();
+
+    let data: Box<[DataLine]> = original.data_lines().to_vec().into_boxed_slice();
+    let position = original.position_bits();
+    let rebuilt = QVector::from_raw_parts(data, position);
+    assert_eq!(original, rebuilt);
+    for i in 0..original.len() {
+        assert_eq!(original.get(i), rebuilt.get(i));
+    }
+}
+
+#[test]
+fn rsqvector_from_parts_eq() {
+    let original: RSQVector256 = (0..2000u64).map(|x| x % 4).collect();
+    let qv = QVector::from_raw_parts(
+        original.qvector().data_lines().to_vec().into_boxed_slice(),
+        original.qvector().position_bits(),
+    );
+    let rs = original.rs_support();
+    let superblocks: Box<[SuperblockPlain]> = rs.superblocks().to_vec().into_boxed_slice();
+    let select_samples: [Box<[u32]>; 4] = std::array::from_fn(|s| {
+        rs.select_samples(s).to_vec().into_boxed_slice()
+    });
+    let rs_rebuilt = RSSupportPlain::<256>::from_parts(superblocks, select_samples);
+    let rebuilt = RSQVector256::from_parts(qv, rs_rebuilt, original.n_occs_smaller());
+    assert_eq!(original, rebuilt);
+}
+
+#[test]
+fn qwt_from_parts_eq_queries() {
+    let data: Vec<u32> = (0..500).map(|x| (x * 7) % 64).collect();
+    let original = QWT256::from(data.clone());
+
+    let levels: Vec<_> = original
+        .levels()
+        .iter()
+        .map(|rs| {
+            let qv = QVector::from_raw_parts(
+                rs.qvector().data_lines().to_vec().into_boxed_slice(),
+                rs.qvector().position_bits(),
+            );
+            let support = rs.rs_support();
+            let superblocks = support.superblocks().to_vec().into_boxed_slice();
+            let select_samples = std::array::from_fn(|s| {
+                support.select_samples(s).to_vec().into_boxed_slice()
+            });
+            let rs_support = RSSupportPlain::<256>::from_parts(superblocks, select_samples);
+            RSQVector256::from_parts(qv, rs_support, rs.n_occs_smaller())
+        })
+        .collect();
+
+    let rebuilt = QWT256::from_parts(original.len(), original.sigma_raw(), levels).unwrap();
+    assert_eq!(original.len(), rebuilt.len());
+    assert_eq!(original.n_levels(), rebuilt.n_levels());
+    for i in 0..data.len() {
+        assert_eq!(original.get(i), rebuilt.get(i), "get mismatch at {i}");
+    }
+    for &sym in &[0u32, 1, 7, 31, 63] {
+        for i in (0..=data.len()).step_by(17) {
+            assert_eq!(
+                original.rank(sym, i),
+                rebuilt.rank(sym, i),
+                "rank({sym},{i})"
+            );
+        }
+        if let Some(cnt) = original.rank(sym, data.len()) {
+            for k in 0..cnt.min(5) {
+                assert_eq!(
+                    original.select(sym, k),
+                    rebuilt.select(sym, k),
+                    "select({sym},{k})"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn hqwt_from_parts_eq_queries() {
+    let data: Vec<u32> = (0..800)
+        .map(|x| {
+            // Uneven freqs so Huffman codes matter.
+            if x % 10 == 0 {
+                0
+            } else {
+                (x % 40) + 1
+            }
+        })
+        .collect();
+    let original = HQWT256::from(data.clone());
+
+    let levels: Vec<_> = original
+        .levels()
+        .iter()
+        .map(|rs| {
+            let qv = QVector::from_raw_parts(
+                rs.qvector().data_lines().to_vec().into_boxed_slice(),
+                rs.qvector().position_bits(),
+            );
+            let support = rs.rs_support();
+            let superblocks = support.superblocks().to_vec().into_boxed_slice();
+            let select_samples = std::array::from_fn(|s| {
+                support.select_samples(s).to_vec().into_boxed_slice()
+            });
+            let rs_support = RSSupportPlain::<256>::from_parts(superblocks, select_samples);
+            RSQVector256::from_parts(qv, rs_support, rs.n_occs_smaller())
+        })
+        .collect();
+
+    let rebuilt = HQWT256::from_parts(
+        original.len(),
+        original.n_levels(),
+        original.codes_encode().to_vec(),
+        original.codes_decode().to_vec(),
+        levels,
+        original.level_lens().to_vec(),
+    )
+    .unwrap();
+
+    assert_eq!(original.len(), rebuilt.len());
+    for i in 0..data.len() {
+        assert_eq!(original.get(i), rebuilt.get(i), "hqwt get mismatch at {i}");
+    }
+    for &sym in &[0u32, 1, 5, 20, 40] {
+        for i in (0..=data.len()).step_by(23) {
+            assert_eq!(
+                original.rank(sym, i),
+                rebuilt.rank(sym, i),
+                "hqwt rank({sym},{i})"
+            );
+        }
+    }
+}
+
+#[test]
+fn qwt_pfs_from_parts_rejected() {
+    use crate::QWT256Pfs;
+    let err = QWT256Pfs::<u32>::from_parts(0, 0, vec![]).unwrap_err();
+    assert_eq!(err, crate::bytes::LayoutError::PrefetchNotSupported);
+}

--- a/src/bytes/from_parts_tests.rs
+++ b/src/bytes/from_parts_tests.rs
@@ -3,7 +3,8 @@
 use crate::qvector::rs_qvector::{RSQVector256, RSSupportPlain};
 use crate::qvector::{DataLine, QVector};
 use crate::{
-    AccessQuad, AccessUnsigned, RankUnsigned, SelectUnsigned, SuperblockPlain, HQWT256, QWT256,
+    AccessQuad, AccessUnsigned, PrefixCode, RankUnsigned, SelectUnsigned, SuperblockPlain, HQWT256,
+    QWT256,
 };
 
 #[test]
@@ -33,6 +34,25 @@ fn rsqvector_from_parts_eq() {
     let rs_rebuilt = RSSupportPlain::<256>::from_parts(superblocks, select_samples);
     let rebuilt = RSQVector256::from_parts(qv, rs_rebuilt, original.n_occs_smaller());
     assert_eq!(original, rebuilt);
+}
+
+fn clone_hqwt_levels(original: &HQWT256<u32>) -> Vec<RSQVector256> {
+    original
+        .levels()
+        .iter()
+        .map(|rs| {
+            let qv = QVector::from_raw_parts(
+                rs.qvector().data_lines().to_vec().into_boxed_slice(),
+                rs.qvector().position_bits(),
+            );
+            let support = rs.rs_support();
+            let superblocks = support.superblocks().to_vec().into_boxed_slice();
+            let select_samples =
+                std::array::from_fn(|s| support.select_samples(s).to_vec().into_boxed_slice());
+            let rs_support = RSSupportPlain::<256>::from_parts(superblocks, select_samples);
+            RSQVector256::from_parts(qv, rs_support, rs.n_occs_smaller())
+        })
+        .collect()
 }
 
 #[test]
@@ -91,6 +111,52 @@ fn qwt_from_parts_eq_queries() {
 }
 
 #[test]
+fn hqwt_from_parts_rejects_terminal_prefix_with_populated_descendants() {
+    let data: Vec<u32> = (0..800)
+        .map(|x| if x % 10 == 0 { 0 } else { (x % 40) + 1 })
+        .collect();
+    let original = HQWT256::from(data);
+    let mut codes_encode = original.codes_encode().to_vec();
+    let mut codes_decode = original.codes_decode().to_vec();
+    let long_code = codes_encode
+        .iter()
+        .find(|code| code.len >= 4)
+        .expect("control tree must contain a multi-level code");
+    let prefix = PrefixCode {
+        content: long_code.content >> 2,
+        len: long_code.len - 2,
+    };
+    let synthetic_symbol = codes_encode.len() as u32;
+    codes_encode.push(prefix.clone());
+    let bucket = &mut codes_decode[prefix.len as usize];
+    assert!(
+        bucket
+            .binary_search_by_key(&prefix.content, |(content, _)| *content)
+            .is_err(),
+        "a valid Huffman table must not already terminate at this prefix"
+    );
+    bucket.push((prefix.content, synthetic_symbol));
+    bucket.sort_unstable();
+
+    let error = HQWT256::from_parts(
+        original.len(),
+        original.n_levels(),
+        codes_encode,
+        codes_decode,
+        clone_hqwt_levels(&original),
+        original.level_lens().to_vec(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        crate::bytes::LayoutError::Inconsistent {
+            detail: "Huffman decode entry has a populated descendant"
+        }
+    ));
+}
+
+#[test]
 fn hqwt_from_parts_eq_queries() {
     let data: Vec<u32> = (0..800)
         .map(|x| {
@@ -104,22 +170,7 @@ fn hqwt_from_parts_eq_queries() {
         .collect();
     let original = HQWT256::from(data.clone());
 
-    let levels: Vec<_> = original
-        .levels()
-        .iter()
-        .map(|rs| {
-            let qv = QVector::from_raw_parts(
-                rs.qvector().data_lines().to_vec().into_boxed_slice(),
-                rs.qvector().position_bits(),
-            );
-            let support = rs.rs_support();
-            let superblocks = support.superblocks().to_vec().into_boxed_slice();
-            let select_samples =
-                std::array::from_fn(|s| support.select_samples(s).to_vec().into_boxed_slice());
-            let rs_support = RSSupportPlain::<256>::from_parts(superblocks, select_samples);
-            RSQVector256::from_parts(qv, rs_support, rs.n_occs_smaller())
-        })
-        .collect();
+    let levels = clone_hqwt_levels(&original);
 
     let rebuilt = HQWT256::from_parts(
         original.len(),

--- a/src/bytes/hqwb.rs
+++ b/src/bytes/hqwb.rs
@@ -140,7 +140,14 @@ fn get_u64(buf: &[u8], o: &mut usize) -> u64 {
     v
 }
 
-/// Serialize a plain HQWT256 into an `HQWB` blob.
+/// Serialize a plain [`HQWT256`](crate::HQWT256) into an `HQWB` blob.
+///
+/// Self-contained little-endian byte vector. Source need not be 64-aligned for
+/// a later [`hqwt256_from_bytes`] call (owned path copies POD payloads).
+///
+/// # Errors
+/// Returns [`LayoutError::NotLittleEndian`] on big-endian hosts, or
+/// [`LayoutError::Inconsistent`] if a code table exceeds `u16` length fields.
 pub fn hqwt256_to_bytes<T>(
     tree: &HuffQWaveletTree<T, RSQVector<RSSupportPlain<256>>, false>,
 ) -> Result<Vec<u8>, LayoutError>
@@ -151,7 +158,9 @@ where
     to_bytes_generic::<T, 256>(tree)
 }
 
-/// Serialize a plain HQWT512 into an `HQWB` blob.
+/// Serialize a plain [`HQWT512`](crate::HQWT512) into an `HQWB` blob.
+///
+/// See [`hqwt256_to_bytes`].
 pub fn hqwt512_to_bytes<T>(
     tree: &HuffQWaveletTree<T, RSQVector<RSSupportPlain<512>>, false>,
 ) -> Result<Vec<u8>, LayoutError>
@@ -326,7 +335,13 @@ where
     Ok(out)
 }
 
-/// Deserialize an `HQWB` blob into an owned HQWT256.
+/// Deserialize an `HQWB` blob into an owned [`HQWT256`](crate::HQWT256).
+///
+/// Copies POD payloads onto the heap, so `bytes` need not be 64-byte aligned.
+/// For a zero-copy alternative see [`crate::bytes::HqwtView`].
+///
+/// # Errors
+/// See [`LayoutError`].
 pub fn hqwt256_from_bytes<T>(
     bytes: &[u8],
 ) -> Result<HuffQWaveletTree<T, RSQVector<RSSupportPlain<256>>, false>, LayoutError>
@@ -338,7 +353,9 @@ where
     from_bytes_generic::<T, 256>(bytes)
 }
 
-/// Deserialize an `HQWB` blob into an owned HQWT512.
+/// Deserialize an `HQWB` blob into an owned [`HQWT512`](crate::HQWT512).
+///
+/// See [`hqwt256_from_bytes`].
 pub fn hqwt512_from_bytes<T>(
     bytes: &[u8],
 ) -> Result<HuffQWaveletTree<T, RSQVector<RSSupportPlain<512>>, false>, LayoutError>

--- a/src/bytes/hqwb.rs
+++ b/src/bytes/hqwb.rs
@@ -18,13 +18,13 @@
 //! ```
 
 use super::{
-    align_up, copy_pod_slice, ensure_le, LayoutError, FLAG_B512, FLAG_PREFETCH, FORMAT_VERSION,
-    HEADER_SIZE, HQWB_MAGIC, HQWT_LEVEL_DIR_SIZE, LEVEL_DIR_SIZE,
+    align_up, checked_region, copy_pod_slice, ensure_le, LayoutError, FLAG_B512, FLAG_PREFETCH,
+    FORMAT_VERSION, HEADER_SIZE, HQWB_MAGIC, HQWT_LEVEL_DIR_SIZE, LEVEL_DIR_SIZE,
 };
-use crate::qvector::rs_qvector::{RSQVector, RSSupportPlain, SuperblockPlain};
-use crate::qvector::{DataLine, QVector};
 use crate::quadwt::huffqwt::{HuffQWaveletTree, PrefixCode};
 use crate::quadwt::{RSforWT, WTIndexable};
+use crate::qvector::rs_qvector::{RSQVector, RSSupportPlain, SuperblockPlain};
+use crate::qvector::{DataLine, QVector};
 use num_traits::AsPrimitive;
 use std::mem::size_of;
 
@@ -192,7 +192,6 @@ where
     // On-disk PrefixCode is always content:u32 + len:u32 = 8 B (not memcpy of struct).
     cursor += encode_len * 8;
 
-
     // Decode flatten size
     let mut decode_bytes = 0usize;
     for bucket in decode {
@@ -303,16 +302,14 @@ where
 
         let off = dir.off_data as usize;
         let nbytes = dir.n_datalines as usize * size_of::<DataLine>();
-        let src = unsafe {
-            std::slice::from_raw_parts(qv.data_lines().as_ptr() as *const u8, nbytes)
-        };
+        let src =
+            unsafe { std::slice::from_raw_parts(qv.data_lines().as_ptr() as *const u8, nbytes) };
         out[off..off + nbytes].copy_from_slice(src);
 
         let off = dir.off_superblocks as usize;
         let nbytes = dir.n_superblocks as usize * size_of::<SuperblockPlain>();
-        let src = unsafe {
-            std::slice::from_raw_parts(rs.superblocks().as_ptr() as *const u8, nbytes)
-        };
+        let src =
+            unsafe { std::slice::from_raw_parts(rs.superblocks().as_ptr() as *const u8, nbytes) };
         out[off..off + nbytes].copy_from_slice(src);
 
         for s in 0..4 {
@@ -405,11 +402,8 @@ where
     // Code tables start at 8-aligned offset after directory.
     let mut p = align_up(dir_end, 8);
 
-    // Encode LUT
-    let encode_bytes = encode_len * 8;
-    if p + encode_bytes > bytes.len() {
-        return Err(LayoutError::Truncated);
-    }
+    // Encode LUT (content:u32 + len:u32 = 8 B per entry)
+    let encode_bytes = checked_region(p, encode_len, 8, bytes.len())?;
     let mut codes_encode = Vec::with_capacity(encode_len);
     for i in 0..encode_len {
         let base = p + i * 8;
@@ -422,15 +416,11 @@ where
     // Decode LUT
     let mut codes_decode: Vec<Vec<(u32, T)>> = Vec::with_capacity(decode_n_buckets);
     for _ in 0..decode_n_buckets {
-        if p + 4 > bytes.len() {
-            return Err(LayoutError::Truncated);
-        }
+        let _ = checked_region(p, 1, 4, bytes.len())?;
         let n_entries = u32::from_le_bytes(bytes[p..p + 4].try_into().unwrap()) as usize;
         p += 4;
-        let need = n_entries * 12;
-        if p + need > bytes.len() {
-            return Err(LayoutError::Truncated);
-        }
+        // content:u32 + symbol:u64 = 12 B per entry
+        let need = checked_region(p, n_entries, 12, bytes.len())?;
         let mut bucket = Vec::with_capacity(n_entries);
         for _ in 0..n_entries {
             let content = u32::from_le_bytes(bytes[p..p + 4].try_into().unwrap());
@@ -440,6 +430,7 @@ where
             let sym: T = sym_u.as_();
             bucket.push((content, sym));
         }
+        debug_assert_eq!(need, n_entries * 12);
         codes_decode.push(bucket);
     }
 
@@ -454,32 +445,29 @@ where
             return Err(LayoutError::Misaligned);
         }
         let data_off = dir.off_data as usize;
-        let data_bytes = dir.n_datalines as usize * size_of::<DataLine>();
-        if data_off + data_bytes > bytes.len() {
-            return Err(LayoutError::Truncated);
-        }
-        let lines = copy_pod_slice::<DataLine>(&bytes[data_off..], dir.n_datalines as usize)?;
+        let n_datalines = dir.n_datalines as usize;
+        let _ = checked_region(data_off, n_datalines, size_of::<DataLine>(), bytes.len())?;
+        let lines = copy_pod_slice::<DataLine>(&bytes[data_off..], n_datalines)?;
         let qv = QVector::from_raw_parts(lines, dir.position_bits as usize);
 
         if dir.off_superblocks as usize % 64 != 0 {
             return Err(LayoutError::Misaligned);
         }
         let sb_off = dir.off_superblocks as usize;
-        let sb_bytes = dir.n_superblocks as usize * size_of::<SuperblockPlain>();
-        if sb_off + sb_bytes > bytes.len() {
-            return Err(LayoutError::Truncated);
-        }
-        let superblocks =
-            copy_pod_slice::<SuperblockPlain>(&bytes[sb_off..], dir.n_superblocks as usize)?;
+        let n_superblocks = dir.n_superblocks as usize;
+        let _ = checked_region(
+            sb_off,
+            n_superblocks,
+            size_of::<SuperblockPlain>(),
+            bytes.len(),
+        )?;
+        let superblocks = copy_pod_slice::<SuperblockPlain>(&bytes[sb_off..], n_superblocks)?;
 
         let mut select_samples: [Box<[u32]>; 4] = Default::default();
         for s in 0..4 {
             let n_sel = dir.n_sel[s] as usize;
             let off = dir.off_sel[s] as usize;
-            let end = off + n_sel * 4;
-            if end > bytes.len() {
-                return Err(LayoutError::Truncated);
-            }
+            let _ = checked_region(off, n_sel, size_of::<u32>(), bytes.len())?;
             let mut v = Vec::with_capacity(n_sel);
             for i in 0..n_sel {
                 let b = off + i * 4;
@@ -505,18 +493,12 @@ const _: fn() = || {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{AccessUnsigned, HQWT256, RankUnsigned, SelectUnsigned};
+    use crate::{AccessUnsigned, RankUnsigned, SelectUnsigned, HQWT256};
 
     #[test]
     fn hqwb_roundtrip_get_rank_select() {
         let data: Vec<u32> = (0..800)
-            .map(|x| {
-                if x % 10 == 0 {
-                    0
-                } else {
-                    (x % 40) + 1
-                }
-            })
+            .map(|x| if x % 10 == 0 { 0 } else { (x % 40) + 1 })
             .collect();
         let original = HQWT256::from(data.clone());
         let bytes = hqwt256_to_bytes(&original).unwrap();
@@ -574,13 +556,7 @@ mod tests {
     fn hqwb_large_sigma_uneven() {
         // σ ≈ a few thousand with skewed freqs.
         let data: Vec<u32> = (0..5000)
-            .map(|x| {
-                if x % 50 == 0 {
-                    0
-                } else {
-                    (x % 2000) + 1
-                }
-            })
+            .map(|x| if x % 50 == 0 { 0 } else { (x % 2000) + 1 })
             .collect();
         let original = HQWT256::from(data.clone());
         let bytes = hqwt256_to_bytes(&original).unwrap();

--- a/src/bytes/hqwb.rs
+++ b/src/bytes/hqwb.rs
@@ -80,16 +80,16 @@ impl LevelDir {
         let n_superblocks = get_u32(buf, &mut o);
         let _pad1 = get_u32(buf, &mut o);
         let mut off_sel = [0u64; 4];
-        for i in 0..4 {
-            off_sel[i] = get_u64(buf, &mut o);
+        for slot in &mut off_sel {
+            *slot = get_u64(buf, &mut o);
         }
         let mut n_sel = [0u32; 4];
-        for i in 0..4 {
-            n_sel[i] = get_u32(buf, &mut o);
+        for slot in &mut n_sel {
+            *slot = get_u32(buf, &mut o);
         }
         let mut n_occs_smaller = [0u64; 5];
-        for i in 0..5 {
-            n_occs_smaller[i] = get_u64(buf, &mut o);
+        for slot in &mut n_occs_smaller {
+            *slot = get_u64(buf, &mut o);
         }
         let level_len = get_u64(buf, &mut o);
         Ok(Self {
@@ -441,7 +441,7 @@ where
         let dir_off = HEADER_SIZE + li * HQWT_LEVEL_DIR_SIZE;
         let dir = LevelDir::read(&bytes[dir_off..dir_off + HQWT_LEVEL_DIR_SIZE])?;
 
-        if dir.off_data as usize % 64 != 0 {
+        if !(dir.off_data as usize).is_multiple_of(64) {
             return Err(LayoutError::Misaligned);
         }
         let data_off = dir.off_data as usize;
@@ -450,7 +450,7 @@ where
         let lines = copy_pod_slice::<DataLine>(&bytes[data_off..], n_datalines)?;
         let qv = QVector::from_raw_parts(lines, dir.position_bits as usize);
 
-        if dir.off_superblocks as usize % 64 != 0 {
+        if !(dir.off_superblocks as usize).is_multiple_of(64) {
             return Err(LayoutError::Misaligned);
         }
         let sb_off = dir.off_superblocks as usize;
@@ -464,7 +464,7 @@ where
         let superblocks = copy_pod_slice::<SuperblockPlain>(&bytes[sb_off..], n_superblocks)?;
 
         let mut select_samples: [Box<[u32]>; 4] = Default::default();
-        for s in 0..4 {
+        for (s, sample_slot) in select_samples.iter_mut().enumerate() {
             let n_sel = dir.n_sel[s] as usize;
             let off = dir.off_sel[s] as usize;
             let _ = checked_region(off, n_sel, size_of::<u32>(), bytes.len())?;
@@ -473,7 +473,7 @@ where
                 let b = off + i * 4;
                 v.push(u32::from_le_bytes(bytes[b..b + 4].try_into().unwrap()));
             }
-            select_samples[s] = v.into_boxed_slice();
+            *sample_slot = v.into_boxed_slice();
         }
 
         let rs = RSSupportPlain::<B>::from_parts(superblocks, select_samples);

--- a/src/bytes/hqwb.rs
+++ b/src/bytes/hqwb.rs
@@ -1,0 +1,599 @@
+//! `HQWB` container: owned serialize / deserialize for [`HuffQWaveletTree`].
+//!
+//! Layout (little-endian):
+//!
+//! ```text
+//! [0..4)   magic b"HQWB"
+//! [4..6)   version u16 = 1
+//! [6]      flags u8 (bit0 = B_SIZE=512, bit1 = prefetch — rejected)
+//! [7]      t_width u8 = size_of::<T>()
+//! [8..16)  n u64
+//! [16..18) n_levels u16
+//! [18..20) encode_len u16
+//! [20..22) decode_n_buckets u16
+//! [22..32) reserved 0
+//! [32..)   level directory: n_levels × 136 B  (128 B QWTB dir + level_len u64)
+//!          then 8-aligned code tables
+//!          then 64-aligned POD payloads per level
+//! ```
+
+use super::{
+    align_up, copy_pod_slice, ensure_le, LayoutError, FLAG_B512, FLAG_PREFETCH, FORMAT_VERSION,
+    HEADER_SIZE, HQWB_MAGIC, HQWT_LEVEL_DIR_SIZE, LEVEL_DIR_SIZE,
+};
+use crate::qvector::rs_qvector::{RSQVector, RSSupportPlain, SuperblockPlain};
+use crate::qvector::{DataLine, QVector};
+use crate::quadwt::huffqwt::{HuffQWaveletTree, PrefixCode};
+use crate::quadwt::{RSforWT, WTIndexable};
+use num_traits::AsPrimitive;
+use std::mem::size_of;
+
+/// One HQWT level directory entry (136 bytes = 128 + level_len).
+#[derive(Clone, Debug)]
+struct LevelDir {
+    off_data: u64,
+    n_datalines: u32,
+    position_bits: u64,
+    off_superblocks: u64,
+    n_superblocks: u32,
+    off_sel: [u64; 4],
+    n_sel: [u32; 4],
+    n_occs_smaller: [u64; 5],
+    level_len: u64,
+}
+
+impl LevelDir {
+    fn write(&self, out: &mut [u8]) {
+        debug_assert_eq!(out.len(), HQWT_LEVEL_DIR_SIZE);
+        let mut o = 0;
+        put_u64(out, &mut o, self.off_data);
+        put_u32(out, &mut o, self.n_datalines);
+        put_u32(out, &mut o, 0); // pad0
+        put_u64(out, &mut o, self.position_bits);
+        put_u64(out, &mut o, self.off_superblocks);
+        put_u32(out, &mut o, self.n_superblocks);
+        put_u32(out, &mut o, 0); // pad1
+        for i in 0..4 {
+            put_u64(out, &mut o, self.off_sel[i]);
+        }
+        for i in 0..4 {
+            put_u32(out, &mut o, self.n_sel[i]);
+        }
+        for i in 0..5 {
+            put_u64(out, &mut o, self.n_occs_smaller[i]);
+        }
+        debug_assert_eq!(o, LEVEL_DIR_SIZE);
+        put_u64(out, &mut o, self.level_len);
+        debug_assert_eq!(o, HQWT_LEVEL_DIR_SIZE);
+    }
+
+    fn read(buf: &[u8]) -> Result<Self, LayoutError> {
+        if buf.len() < HQWT_LEVEL_DIR_SIZE {
+            return Err(LayoutError::Truncated);
+        }
+        let mut o = 0;
+        let off_data = get_u64(buf, &mut o);
+        let n_datalines = get_u32(buf, &mut o);
+        let _pad0 = get_u32(buf, &mut o);
+        let position_bits = get_u64(buf, &mut o);
+        let off_superblocks = get_u64(buf, &mut o);
+        let n_superblocks = get_u32(buf, &mut o);
+        let _pad1 = get_u32(buf, &mut o);
+        let mut off_sel = [0u64; 4];
+        for i in 0..4 {
+            off_sel[i] = get_u64(buf, &mut o);
+        }
+        let mut n_sel = [0u32; 4];
+        for i in 0..4 {
+            n_sel[i] = get_u32(buf, &mut o);
+        }
+        let mut n_occs_smaller = [0u64; 5];
+        for i in 0..5 {
+            n_occs_smaller[i] = get_u64(buf, &mut o);
+        }
+        let level_len = get_u64(buf, &mut o);
+        Ok(Self {
+            off_data,
+            n_datalines,
+            position_bits,
+            off_superblocks,
+            n_superblocks,
+            off_sel,
+            n_sel,
+            n_occs_smaller,
+            level_len,
+        })
+    }
+}
+
+#[inline]
+fn put_u16(out: &mut [u8], o: &mut usize, v: u16) {
+    out[*o..*o + 2].copy_from_slice(&v.to_le_bytes());
+    *o += 2;
+}
+#[inline]
+fn put_u32(out: &mut [u8], o: &mut usize, v: u32) {
+    out[*o..*o + 4].copy_from_slice(&v.to_le_bytes());
+    *o += 4;
+}
+#[inline]
+fn put_u64(out: &mut [u8], o: &mut usize, v: u64) {
+    out[*o..*o + 8].copy_from_slice(&v.to_le_bytes());
+    *o += 8;
+}
+#[inline]
+fn get_u16(buf: &[u8], o: &mut usize) -> u16 {
+    let v = u16::from_le_bytes(buf[*o..*o + 2].try_into().unwrap());
+    *o += 2;
+    v
+}
+#[inline]
+fn get_u32(buf: &[u8], o: &mut usize) -> u32 {
+    let v = u32::from_le_bytes(buf[*o..*o + 4].try_into().unwrap());
+    *o += 4;
+    v
+}
+#[inline]
+fn get_u64(buf: &[u8], o: &mut usize) -> u64 {
+    let v = u64::from_le_bytes(buf[*o..*o + 8].try_into().unwrap());
+    *o += 8;
+    v
+}
+
+/// Serialize a plain HQWT256 into an `HQWB` blob.
+pub fn hqwt256_to_bytes<T>(
+    tree: &HuffQWaveletTree<T, RSQVector<RSSupportPlain<256>>, false>,
+) -> Result<Vec<u8>, LayoutError>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+{
+    to_bytes_generic::<T, 256>(tree)
+}
+
+/// Serialize a plain HQWT512 into an `HQWB` blob.
+pub fn hqwt512_to_bytes<T>(
+    tree: &HuffQWaveletTree<T, RSQVector<RSSupportPlain<512>>, false>,
+) -> Result<Vec<u8>, LayoutError>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+{
+    to_bytes_generic::<T, 512>(tree)
+}
+
+fn to_bytes_generic<T, const B: usize>(
+    tree: &HuffQWaveletTree<T, RSQVector<RSSupportPlain<B>>, false>,
+) -> Result<Vec<u8>, LayoutError>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+{
+    ensure_le()?;
+
+    let n_levels = tree.n_levels();
+    let encode = tree.codes_encode();
+    let decode = tree.codes_decode();
+    let encode_len = encode.len();
+    let decode_n_buckets = decode.len();
+
+    if encode_len > u16::MAX as usize || decode_n_buckets > u16::MAX as usize {
+        return Err(LayoutError::Inconsistent {
+            detail: "code table too large for u16 length fields",
+        });
+    }
+
+    let dir_bytes = n_levels * HQWT_LEVEL_DIR_SIZE;
+    let header_and_dir = HEADER_SIZE + dir_bytes;
+
+    // Code tables (after directory, 8-aligned).
+    let mut cursor = align_up(header_and_dir, 8);
+    let off_encode = cursor;
+    // On-disk PrefixCode is always content:u32 + len:u32 = 8 B (not memcpy of struct).
+    cursor += encode_len * 8;
+
+
+    // Decode flatten size
+    let mut decode_bytes = 0usize;
+    for bucket in decode {
+        decode_bytes += 4; // n_entries
+        decode_bytes += bucket.len() * 12; // content u32 + symbol u64
+    }
+    let off_decode = cursor;
+    cursor += decode_bytes;
+
+    // Level payloads
+    let mut dirs = Vec::with_capacity(n_levels);
+    let level_lens = tree.level_lens();
+
+    for (li, level) in tree.levels().iter().take(n_levels).enumerate() {
+        let qv = level.qvector();
+        let rs = level.rs_support();
+        let n_datalines = qv.data_lines().len() as u32;
+        let position_bits = qv.position_bits() as u64;
+        let n_superblocks = rs.superblocks().len() as u32;
+        let n_sel: [u32; 4] = std::array::from_fn(|s| rs.select_samples(s).len() as u32);
+        let n_occs = level.n_occs_smaller();
+        let n_occs_smaller: [u64; 5] = std::array::from_fn(|i| n_occs[i] as u64);
+        let level_len = level_lens.get(li).copied().unwrap_or(0) as u64;
+
+        cursor = align_up(cursor, 64);
+        let off_data = cursor as u64;
+        cursor += n_datalines as usize * size_of::<DataLine>();
+
+        cursor = align_up(cursor, 64);
+        let off_superblocks = cursor as u64;
+        cursor += n_superblocks as usize * size_of::<SuperblockPlain>();
+
+        cursor = align_up(cursor, 4);
+        let mut off_sel = [0u64; 4];
+        for s in 0..4 {
+            off_sel[s] = cursor as u64;
+            cursor += n_sel[s] as usize * size_of::<u32>();
+        }
+
+        dirs.push(LevelDir {
+            off_data,
+            n_datalines,
+            position_bits,
+            off_superblocks,
+            n_superblocks,
+            off_sel,
+            n_sel,
+            n_occs_smaller,
+            level_len,
+        });
+    }
+
+    let mut out = vec![0u8; cursor];
+
+    // Header
+    out[0..4].copy_from_slice(HQWB_MAGIC);
+    let mut o = 4;
+    put_u16(&mut out, &mut o, FORMAT_VERSION);
+    let flags: u8 = if B == 512 { FLAG_B512 } else { 0 };
+    out[o] = flags;
+    o += 1;
+    out[o] = size_of::<T>() as u8;
+    o += 1;
+    put_u64(&mut out, &mut o, tree.len() as u64);
+    put_u16(&mut out, &mut o, n_levels as u16);
+    put_u16(&mut out, &mut o, encode_len as u16);
+    put_u16(&mut out, &mut o, decode_n_buckets as u16);
+    debug_assert_eq!(o, 22);
+    o = HEADER_SIZE;
+
+    // Directory
+    for dir in &dirs {
+        dir.write(&mut out[o..o + HQWT_LEVEL_DIR_SIZE]);
+        o += HQWT_LEVEL_DIR_SIZE;
+    }
+
+    // Encode LUT: PrefixCode is {content: u32, len: u32} — write as LE pairs.
+    // (PrefixCode is not necessarily #[repr(C)], so don't memcpy the struct.)
+    {
+        let mut p = off_encode;
+        for code in encode {
+            out[p..p + 4].copy_from_slice(&code.content.to_le_bytes());
+            out[p + 4..p + 8].copy_from_slice(&code.len.to_le_bytes());
+            p += 8;
+        }
+    }
+
+    // Decode LUT flatten
+    {
+        let mut p = off_decode;
+        for bucket in decode {
+            out[p..p + 4].copy_from_slice(&(bucket.len() as u32).to_le_bytes());
+            p += 4;
+            for &(content, ref sym) in bucket {
+                out[p..p + 4].copy_from_slice(&content.to_le_bytes());
+                p += 4;
+                let sym_u: usize = (*sym).as_();
+                out[p..p + 8].copy_from_slice(&(sym_u as u64).to_le_bytes());
+                p += 8;
+            }
+        }
+    }
+
+    // Level payloads
+    for (level, dir) in tree.levels().iter().zip(dirs.iter()) {
+        let qv = level.qvector();
+        let rs = level.rs_support();
+
+        let off = dir.off_data as usize;
+        let nbytes = dir.n_datalines as usize * size_of::<DataLine>();
+        let src = unsafe {
+            std::slice::from_raw_parts(qv.data_lines().as_ptr() as *const u8, nbytes)
+        };
+        out[off..off + nbytes].copy_from_slice(src);
+
+        let off = dir.off_superblocks as usize;
+        let nbytes = dir.n_superblocks as usize * size_of::<SuperblockPlain>();
+        let src = unsafe {
+            std::slice::from_raw_parts(rs.superblocks().as_ptr() as *const u8, nbytes)
+        };
+        out[off..off + nbytes].copy_from_slice(src);
+
+        for s in 0..4 {
+            let off = dir.off_sel[s] as usize;
+            let n = dir.n_sel[s] as usize;
+            let samples = rs.select_samples(s);
+            debug_assert_eq!(samples.len(), n);
+            for (i, &v) in samples.iter().enumerate() {
+                out[off + i * 4..off + i * 4 + 4].copy_from_slice(&v.to_le_bytes());
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+/// Deserialize an `HQWB` blob into an owned HQWT256.
+pub fn hqwt256_from_bytes<T>(
+    bytes: &[u8],
+) -> Result<HuffQWaveletTree<T, RSQVector<RSSupportPlain<256>>, false>, LayoutError>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+    u8: AsPrimitive<T>,
+{
+    from_bytes_generic::<T, 256>(bytes)
+}
+
+/// Deserialize an `HQWB` blob into an owned HQWT512.
+pub fn hqwt512_from_bytes<T>(
+    bytes: &[u8],
+) -> Result<HuffQWaveletTree<T, RSQVector<RSSupportPlain<512>>, false>, LayoutError>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+    u8: AsPrimitive<T>,
+{
+    from_bytes_generic::<T, 512>(bytes)
+}
+
+fn from_bytes_generic<T, const B: usize>(
+    bytes: &[u8],
+) -> Result<HuffQWaveletTree<T, RSQVector<RSSupportPlain<B>>, false>, LayoutError>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+    u8: AsPrimitive<T>,
+{
+    ensure_le()?;
+    if bytes.len() < HEADER_SIZE {
+        return Err(LayoutError::Truncated);
+    }
+    if &bytes[0..4] != HQWB_MAGIC {
+        return Err(LayoutError::BadMagic);
+    }
+    let mut o = 4;
+    let version = get_u16(bytes, &mut o);
+    if version != FORMAT_VERSION {
+        return Err(LayoutError::BadVersion);
+    }
+    let flags = bytes[o];
+    o += 1;
+    if flags & FLAG_PREFETCH != 0 {
+        return Err(LayoutError::PrefetchNotSupported);
+    }
+    let want_b512 = flags & FLAG_B512 != 0;
+    if (B == 512) != want_b512 {
+        return Err(LayoutError::Inconsistent {
+            detail: "B_SIZE flag does not match requested type",
+        });
+    }
+    let t_width = bytes[o];
+    o += 1;
+    if t_width as usize != size_of::<T>() {
+        return Err(LayoutError::Inconsistent {
+            detail: "t_width does not match T",
+        });
+    }
+    let n = get_u64(bytes, &mut o) as usize;
+    let n_levels = get_u16(bytes, &mut o) as usize;
+    let encode_len = get_u16(bytes, &mut o) as usize;
+    let decode_n_buckets = get_u16(bytes, &mut o) as usize;
+    let _ = o;
+
+    let dir_end = HEADER_SIZE + n_levels * HQWT_LEVEL_DIR_SIZE;
+    if bytes.len() < dir_end {
+        return Err(LayoutError::Truncated);
+    }
+
+    // Code tables start at 8-aligned offset after directory.
+    let mut p = align_up(dir_end, 8);
+
+    // Encode LUT
+    let encode_bytes = encode_len * 8;
+    if p + encode_bytes > bytes.len() {
+        return Err(LayoutError::Truncated);
+    }
+    let mut codes_encode = Vec::with_capacity(encode_len);
+    for i in 0..encode_len {
+        let base = p + i * 8;
+        let content = u32::from_le_bytes(bytes[base..base + 4].try_into().unwrap());
+        let len = u32::from_le_bytes(bytes[base + 4..base + 8].try_into().unwrap());
+        codes_encode.push(PrefixCode { content, len });
+    }
+    p += encode_bytes;
+
+    // Decode LUT
+    let mut codes_decode: Vec<Vec<(u32, T)>> = Vec::with_capacity(decode_n_buckets);
+    for _ in 0..decode_n_buckets {
+        if p + 4 > bytes.len() {
+            return Err(LayoutError::Truncated);
+        }
+        let n_entries = u32::from_le_bytes(bytes[p..p + 4].try_into().unwrap()) as usize;
+        p += 4;
+        let need = n_entries * 12;
+        if p + need > bytes.len() {
+            return Err(LayoutError::Truncated);
+        }
+        let mut bucket = Vec::with_capacity(n_entries);
+        for _ in 0..n_entries {
+            let content = u32::from_le_bytes(bytes[p..p + 4].try_into().unwrap());
+            p += 4;
+            let sym_u = u64::from_le_bytes(bytes[p..p + 8].try_into().unwrap()) as usize;
+            p += 8;
+            let sym: T = sym_u.as_();
+            bucket.push((content, sym));
+        }
+        codes_decode.push(bucket);
+    }
+
+    // Levels
+    let mut qvs = Vec::with_capacity(n_levels);
+    let mut lens = Vec::with_capacity(n_levels);
+    for li in 0..n_levels {
+        let dir_off = HEADER_SIZE + li * HQWT_LEVEL_DIR_SIZE;
+        let dir = LevelDir::read(&bytes[dir_off..dir_off + HQWT_LEVEL_DIR_SIZE])?;
+
+        if dir.off_data as usize % 64 != 0 {
+            return Err(LayoutError::Misaligned);
+        }
+        let data_off = dir.off_data as usize;
+        let data_bytes = dir.n_datalines as usize * size_of::<DataLine>();
+        if data_off + data_bytes > bytes.len() {
+            return Err(LayoutError::Truncated);
+        }
+        let lines = copy_pod_slice::<DataLine>(&bytes[data_off..], dir.n_datalines as usize)?;
+        let qv = QVector::from_raw_parts(lines, dir.position_bits as usize);
+
+        if dir.off_superblocks as usize % 64 != 0 {
+            return Err(LayoutError::Misaligned);
+        }
+        let sb_off = dir.off_superblocks as usize;
+        let sb_bytes = dir.n_superblocks as usize * size_of::<SuperblockPlain>();
+        if sb_off + sb_bytes > bytes.len() {
+            return Err(LayoutError::Truncated);
+        }
+        let superblocks =
+            copy_pod_slice::<SuperblockPlain>(&bytes[sb_off..], dir.n_superblocks as usize)?;
+
+        let mut select_samples: [Box<[u32]>; 4] = Default::default();
+        for s in 0..4 {
+            let n_sel = dir.n_sel[s] as usize;
+            let off = dir.off_sel[s] as usize;
+            let end = off + n_sel * 4;
+            if end > bytes.len() {
+                return Err(LayoutError::Truncated);
+            }
+            let mut v = Vec::with_capacity(n_sel);
+            for i in 0..n_sel {
+                let b = off + i * 4;
+                v.push(u32::from_le_bytes(bytes[b..b + 4].try_into().unwrap()));
+            }
+            select_samples[s] = v.into_boxed_slice();
+        }
+
+        let rs = RSSupportPlain::<B>::from_parts(superblocks, select_samples);
+        let n_occs: [usize; 5] = std::array::from_fn(|i| dir.n_occs_smaller[i] as usize);
+        qvs.push(RSQVector::from_parts(qv, rs, n_occs));
+        lens.push(dir.level_len as usize);
+    }
+
+    HuffQWaveletTree::from_parts(n, n_levels, codes_encode, codes_decode, qvs, lens)
+}
+
+const _: fn() = || {
+    fn assert_rsforwt<T: RSforWT>() {}
+    let _ = assert_rsforwt::<RSQVector<RSSupportPlain<256>>>;
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AccessUnsigned, HQWT256, RankUnsigned, SelectUnsigned};
+
+    #[test]
+    fn hqwb_roundtrip_get_rank_select() {
+        let data: Vec<u32> = (0..800)
+            .map(|x| {
+                if x % 10 == 0 {
+                    0
+                } else {
+                    (x % 40) + 1
+                }
+            })
+            .collect();
+        let original = HQWT256::from(data.clone());
+        let bytes = hqwt256_to_bytes(&original).unwrap();
+        assert_eq!(&bytes[0..4], HQWB_MAGIC);
+        let rebuilt: HQWT256<u32> = hqwt256_from_bytes(&bytes).unwrap();
+
+        assert_eq!(original.len(), rebuilt.len());
+        assert_eq!(original.n_levels(), rebuilt.n_levels());
+        assert_eq!(original.codes_encode(), rebuilt.codes_encode());
+        assert_eq!(original.level_lens(), rebuilt.level_lens());
+
+        for i in 0..data.len() {
+            assert_eq!(original.get(i), rebuilt.get(i), "get@{i}");
+        }
+        for &sym in &[0u32, 1, 5, 20, 40] {
+            for i in (0..=data.len()).step_by(23) {
+                assert_eq!(
+                    original.rank(sym, i),
+                    rebuilt.rank(sym, i),
+                    "rank({sym},{i})"
+                );
+            }
+            if let Some(cnt) = original.rank(sym, data.len()) {
+                for k in 0..cnt.min(3) {
+                    assert_eq!(
+                        original.select(sym, k),
+                        rebuilt.select(sym, k),
+                        "select({sym},{k})"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn hqwb_empty_tree() {
+        let mut empty: Vec<u32> = vec![];
+        let original = HQWT256::new(&mut empty);
+        let bytes = hqwt256_to_bytes(&original).unwrap();
+        let rebuilt: HQWT256<u32> = hqwt256_from_bytes(&bytes).unwrap();
+        assert_eq!(rebuilt.len(), 0);
+        assert!(rebuilt.is_empty());
+        assert_eq!(rebuilt.n_levels(), 0);
+    }
+
+    #[test]
+    fn hqwb_bad_magic() {
+        let mut bytes = hqwt256_to_bytes(&HQWT256::from(vec![1u32, 2, 3])).unwrap();
+        bytes[0] = b'X';
+        let err = hqwt256_from_bytes::<u32>(&bytes).unwrap_err();
+        assert_eq!(err, LayoutError::BadMagic);
+    }
+
+    #[test]
+    fn hqwb_large_sigma_uneven() {
+        // σ ≈ a few thousand with skewed freqs.
+        let data: Vec<u32> = (0..5000)
+            .map(|x| {
+                if x % 50 == 0 {
+                    0
+                } else {
+                    (x % 2000) + 1
+                }
+            })
+            .collect();
+        let original = HQWT256::from(data.clone());
+        let bytes = hqwt256_to_bytes(&original).unwrap();
+        let rebuilt: HQWT256<u32> = hqwt256_from_bytes(&bytes).unwrap();
+        for i in (0..data.len()).step_by(97) {
+            assert_eq!(original.get(i), rebuilt.get(i), "get@{i}");
+        }
+        for &sym in &[0u32, 1, 100, 999, 1999] {
+            assert_eq!(
+                original.rank(sym, data.len()),
+                rebuilt.rank(sym, data.len()),
+                "rank({sym})"
+            );
+        }
+    }
+}

--- a/src/bytes/hqwb.rs
+++ b/src/bytes/hqwb.rs
@@ -410,8 +410,16 @@ where
     let encode_len = get_u16(bytes, &mut o) as usize;
     let decode_n_buckets = get_u16(bytes, &mut o) as usize;
     let _ = o;
+    if n_levels > crate::MAX_QUAD_LEVELS || (n > 0 && n_levels == 0) {
+        return Err(LayoutError::Inconsistent {
+            detail: "Huffman QWT level count is invalid",
+        });
+    }
 
-    let dir_end = HEADER_SIZE + n_levels * HQWT_LEVEL_DIR_SIZE;
+    let dir_end = n_levels
+        .checked_mul(HQWT_LEVEL_DIR_SIZE)
+        .and_then(|size| HEADER_SIZE.checked_add(size))
+        .ok_or(LayoutError::Truncated)?;
     if bytes.len() < dir_end {
         return Err(LayoutError::Truncated);
     }
@@ -445,6 +453,11 @@ where
             let sym_u = u64::from_le_bytes(bytes[p..p + 8].try_into().unwrap()) as usize;
             p += 8;
             let sym: T = sym_u.as_();
+            if sym.as_() != sym_u {
+                return Err(LayoutError::Inconsistent {
+                    detail: "Huffman decode symbol does not fit the requested type",
+                });
+            }
             bucket.push((content, sym));
         }
         debug_assert_eq!(need, n_entries * 12);
@@ -464,8 +477,18 @@ where
         let data_off = dir.off_data as usize;
         let n_datalines = dir.n_datalines as usize;
         let _ = checked_region(data_off, n_datalines, size_of::<DataLine>(), bytes.len())?;
-        let lines = copy_pod_slice::<DataLine>(&bytes[data_off..], n_datalines)?;
-        let qv = QVector::from_raw_parts(lines, dir.position_bits as usize);
+        // SAFETY: DataLine is repr(C), contains only integers, and accepts every bit pattern.
+        let lines = unsafe { copy_pod_slice::<DataLine>(&bytes[data_off..], n_datalines)? };
+        let position_bits =
+            usize::try_from(dir.position_bits).map_err(|_| LayoutError::Inconsistent {
+                detail: "position_bits exceeds usize",
+            })?;
+        if !position_bits.is_multiple_of(2) || position_bits > n_datalines.saturating_mul(512) {
+            return Err(LayoutError::Inconsistent {
+                detail: "position_bits is invalid for the data payload",
+            });
+        }
+        let qv = QVector::from_raw_parts(lines, position_bits);
 
         if !(dir.off_superblocks as usize).is_multiple_of(64) {
             return Err(LayoutError::Misaligned);
@@ -478,24 +501,14 @@ where
             size_of::<SuperblockPlain>(),
             bytes.len(),
         )?;
-        let superblocks = copy_pod_slice::<SuperblockPlain>(&bytes[sb_off..], n_superblocks)?;
 
-        let mut select_samples: [Box<[u32]>; 4] = Default::default();
-        for (s, sample_slot) in select_samples.iter_mut().enumerate() {
+        for s in 0..4 {
             let n_sel = dir.n_sel[s] as usize;
             let off = dir.off_sel[s] as usize;
             let _ = checked_region(off, n_sel, size_of::<u32>(), bytes.len())?;
-            let mut v = Vec::with_capacity(n_sel);
-            for i in 0..n_sel {
-                let b = off + i * 4;
-                v.push(u32::from_le_bytes(bytes[b..b + 4].try_into().unwrap()));
-            }
-            *sample_slot = v.into_boxed_slice();
         }
 
-        let rs = RSSupportPlain::<B>::from_parts(superblocks, select_samples);
-        let n_occs: [usize; 5] = std::array::from_fn(|i| dir.n_occs_smaller[i] as usize);
-        qvs.push(RSQVector::from_parts(qv, rs, n_occs));
+        qvs.push(RSQVector::<RSSupportPlain<B>>::from(qv));
         lens.push(dir.level_len as usize);
     }
 

--- a/src/bytes/level.rs
+++ b/src/bytes/level.rs
@@ -198,11 +198,36 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
         self.position_bits == 0
     }
 
+    /// Bit cursor (`2 * len()`).
+    #[inline]
+    pub fn position_bits(&self) -> usize {
+        self.position_bits
+    }
+
+    /// Borrowed data lines (POD).
+    #[inline]
+    pub fn data_lines(&self) -> &'a [DataLine] {
+        self.data
+    }
+
+    /// Borrowed superblock counters (POD).
+    #[inline]
+    pub fn superblocks(&self) -> &'a [SuperblockPlain] {
+        self.superblocks
+    }
+
+    /// Borrowed select samples for symbol `s ∈ 0..4`.
+    #[inline]
+    pub fn select_samples(&self, s: usize) -> &'a [u32] {
+        self.select_samples[s]
+    }
+
     /// Wavelet-matrix child offsets (`n_occs_smaller`).
     #[inline]
     pub fn n_occs_smaller(&self) -> [usize; 5] {
         self.n_occs_smaller
     }
+
 
     /// Occurrences of all symbols strictly smaller than `symbol` (0..3).
     #[inline(always)]

--- a/src/bytes/level.rs
+++ b/src/bytes/level.rs
@@ -136,7 +136,11 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
         let data_bytes = n_data
             .checked_mul(size_of::<DataLine>())
             .ok_or(LayoutError::Truncated)?;
-        if data_off.checked_add(data_bytes).ok_or(LayoutError::Truncated)? > bytes.len() {
+        if data_off
+            .checked_add(data_bytes)
+            .ok_or(LayoutError::Truncated)?
+            > bytes.len()
+        {
             return Err(LayoutError::Truncated);
         }
         let data = cast_slice::<DataLine>(&bytes[data_off..data_off + data_bytes])?;
@@ -227,7 +231,6 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
     pub fn n_occs_smaller(&self) -> [usize; 5] {
         self.n_occs_smaller
     }
-
 
     /// Occurrences of all symbols strictly smaller than `symbol` (0..3).
     #[inline(always)]
@@ -436,11 +439,8 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
         let n_lines = if B_SIZE == 256 { 1 } else { 2 };
         let mut result = 0usize;
         for j in 0..n_lines {
-            let (word_0, word_1) = unsafe {
-                self.data
-                    .get_unchecked(line_id + j)
-                    .normalize(symbol)
-            };
+            let (word_0, word_1) =
+                unsafe { self.data.get_unchecked(line_id + j).normalize(symbol) };
             let cnt_0 = word_0.count_ones() as usize;
             if cnt_0 > rem {
                 return result + select_in_word_u128(word_0, rem as u64) as usize;

--- a/src/bytes/level.rs
+++ b/src/bytes/level.rs
@@ -1,0 +1,469 @@
+//! Borrowed per-level rank/select views over QWTB/HQWB POD payloads.
+//!
+//! These views are the zero-copy counterpart of [`crate::RSQVector`]: they
+//! borrow `DataLine` / `SuperblockPlain` / select-sample slices that live in a
+//! caller-owned byte buffer (typically an mmap) and implement the same
+//! level-local get / rank / select algorithms.
+
+use super::{cast_slice, LayoutError, LEVEL_DIR_SIZE};
+use crate::qvector::rs_qvector::SuperblockPlain;
+use crate::qvector::DataLine;
+use crate::utils::select_in_word_u128;
+use crate::{AccessQuad, RankQuad};
+use std::mem::size_of;
+
+/// Select sampling stride used by `RSSupportPlain` (every 2^13 occurrences).
+const SELECT_NUM_SAMPLES: usize = 1 << 13;
+/// Blocks per superblock (matches `RSSupportPlain`).
+const BLOCKS_IN_SUPERBLOCK: usize = 8;
+
+/// One plain-QWT level directory entry (128 bytes, packed LE).
+///
+/// Shared by the owned `from_bytes` path and zero-copy views.
+#[derive(Clone, Debug)]
+pub(crate) struct LevelDir {
+    pub off_data: u64,
+    pub n_datalines: u32,
+    pub position_bits: u64,
+    pub off_superblocks: u64,
+    pub n_superblocks: u32,
+    pub off_sel: [u64; 4],
+    pub n_sel: [u32; 4],
+    pub n_occs_smaller: [u64; 5],
+}
+
+impl LevelDir {
+    pub(crate) fn read(buf: &[u8]) -> Result<Self, LayoutError> {
+        if buf.len() < LEVEL_DIR_SIZE {
+            return Err(LayoutError::Truncated);
+        }
+        let mut o = 0;
+        let off_data = get_u64(buf, &mut o);
+        let n_datalines = get_u32(buf, &mut o);
+        let _pad0 = get_u32(buf, &mut o);
+        let position_bits = get_u64(buf, &mut o);
+        let off_superblocks = get_u64(buf, &mut o);
+        let n_superblocks = get_u32(buf, &mut o);
+        let _pad1 = get_u32(buf, &mut o);
+        let mut off_sel = [0u64; 4];
+        for i in 0..4 {
+            off_sel[i] = get_u64(buf, &mut o);
+        }
+        let mut n_sel = [0u32; 4];
+        for i in 0..4 {
+            n_sel[i] = get_u32(buf, &mut o);
+        }
+        let mut n_occs_smaller = [0u64; 5];
+        for i in 0..5 {
+            n_occs_smaller[i] = get_u64(buf, &mut o);
+        }
+        debug_assert_eq!(o, LEVEL_DIR_SIZE);
+        Ok(Self {
+            off_data,
+            n_datalines,
+            position_bits,
+            off_superblocks,
+            n_superblocks,
+            off_sel,
+            n_sel,
+            n_occs_smaller,
+        })
+    }
+}
+
+/// HQWT level directory = plain dir + `level_len` u64 (136 B).
+#[derive(Clone, Debug)]
+pub(crate) struct HqwtLevelDir {
+    pub plain: LevelDir,
+    pub level_len: u64,
+}
+
+impl HqwtLevelDir {
+    pub(crate) fn read(buf: &[u8]) -> Result<Self, LayoutError> {
+        if buf.len() < LEVEL_DIR_SIZE + 8 {
+            return Err(LayoutError::Truncated);
+        }
+        let plain = LevelDir::read(&buf[..LEVEL_DIR_SIZE])?;
+        let mut o = LEVEL_DIR_SIZE;
+        let level_len = get_u64(buf, &mut o);
+        Ok(Self { plain, level_len })
+    }
+}
+
+#[inline]
+fn get_u32(buf: &[u8], o: &mut usize) -> u32 {
+    let v = u32::from_le_bytes(buf[*o..*o + 4].try_into().unwrap());
+    *o += 4;
+    v
+}
+
+#[inline]
+fn get_u64(buf: &[u8], o: &mut usize) -> u64 {
+    let v = u64::from_le_bytes(buf[*o..*o + 8].try_into().unwrap());
+    *o += 8;
+    v
+}
+
+/// Borrowing view of one RS-augmented quad-vector level.
+///
+/// `B_SIZE` is the block size (256 or 512), matching `RSSupportPlain<B_SIZE>`.
+#[derive(Clone, Copy, Debug)]
+pub struct RSQVectorView<'a, const B_SIZE: usize = 256> {
+    data: &'a [DataLine],
+    superblocks: &'a [SuperblockPlain],
+    select_samples: [&'a [u32]; 4],
+    /// Bit cursor (`2 * n_symbols`).
+    position_bits: usize,
+    /// Wavelet-matrix child offsets (5 counters).
+    n_occs_smaller: [usize; 5],
+}
+
+impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
+    /// Open a level from a full container blob and a parsed directory entry.
+    ///
+    /// Requires the **absolute** addresses of data/superblock slices to be
+    /// 64-byte aligned (format offsets are 64-aligned; the base buffer must
+    /// also be 64-aligned for zero-copy casting).
+    pub(crate) fn from_dir(bytes: &'a [u8], dir: &LevelDir) -> Result<Self, LayoutError> {
+        debug_assert!(B_SIZE == 256 || B_SIZE == 512);
+
+        if dir.off_data as usize % 64 != 0 || dir.off_superblocks as usize % 64 != 0 {
+            return Err(LayoutError::Misaligned);
+        }
+
+        let data_off = dir.off_data as usize;
+        let n_data = dir.n_datalines as usize;
+        let data_bytes = n_data
+            .checked_mul(size_of::<DataLine>())
+            .ok_or(LayoutError::Truncated)?;
+        if data_off.checked_add(data_bytes).ok_or(LayoutError::Truncated)? > bytes.len() {
+            return Err(LayoutError::Truncated);
+        }
+        let data = cast_slice::<DataLine>(&bytes[data_off..data_off + data_bytes])?;
+
+        let sb_off = dir.off_superblocks as usize;
+        let n_sb = dir.n_superblocks as usize;
+        let sb_bytes = n_sb
+            .checked_mul(size_of::<SuperblockPlain>())
+            .ok_or(LayoutError::Truncated)?;
+        if sb_off.checked_add(sb_bytes).ok_or(LayoutError::Truncated)? > bytes.len() {
+            return Err(LayoutError::Truncated);
+        }
+        let superblocks = cast_slice::<SuperblockPlain>(&bytes[sb_off..sb_off + sb_bytes])?;
+
+        let mut select_samples: [&'a [u32]; 4] = [&[]; 4];
+        for s in 0..4 {
+            let n_sel = dir.n_sel[s] as usize;
+            let off = dir.off_sel[s] as usize;
+            let need = n_sel
+                .checked_mul(size_of::<u32>())
+                .ok_or(LayoutError::Truncated)?;
+            if off.checked_add(need).ok_or(LayoutError::Truncated)? > bytes.len() {
+                return Err(LayoutError::Truncated);
+            }
+            // u32 LE samples: 4-byte aligned offsets in a 64-aligned base → cast ok.
+            select_samples[s] = cast_slice::<u32>(&bytes[off..off + need])?;
+        }
+
+        let n_occs_smaller: [usize; 5] = std::array::from_fn(|i| dir.n_occs_smaller[i] as usize);
+        let position_bits = dir.position_bits as usize;
+        if position_bits % 2 != 0 {
+            return Err(LayoutError::Inconsistent {
+                detail: "position_bits must be even",
+            });
+        }
+        if position_bits > n_data * 512 {
+            return Err(LayoutError::Inconsistent {
+                detail: "position_bits exceeds data capacity",
+            });
+        }
+
+        Ok(Self {
+            data,
+            superblocks,
+            select_samples,
+            position_bits,
+            n_occs_smaller,
+        })
+    }
+
+    /// Number of 2-bit symbols on this level.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.position_bits >> 1
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.position_bits == 0
+    }
+
+    /// Wavelet-matrix child offsets (`n_occs_smaller`).
+    #[inline]
+    pub fn n_occs_smaller(&self) -> [usize; 5] {
+        self.n_occs_smaller
+    }
+
+    /// Occurrences of all symbols strictly smaller than `symbol` (0..3).
+    #[inline(always)]
+    pub unsafe fn occs_smaller_unchecked(&self, symbol: u8) -> usize {
+        debug_assert!(symbol <= 3);
+        self.n_occs_smaller[symbol as usize]
+    }
+
+    /// Total occurrences of `symbol` (0..3) on this level.
+    #[inline(always)]
+    pub unsafe fn occs_unchecked(&self, symbol: u8) -> usize {
+        debug_assert!(symbol <= 3);
+        self.n_occs_smaller[(symbol + 1) as usize] - self.n_occs_smaller[symbol as usize]
+    }
+
+    /// 2-bit symbol at position `i`.
+    ///
+    /// # Safety
+    /// `i` must be `< self.len()`.
+    #[inline(always)]
+    pub unsafe fn get_unchecked(&self, i: usize) -> u8 {
+        debug_assert!(i < self.len());
+        let line = i >> 8;
+        let pos = i & 255;
+        self.data.get_unchecked(line).get_unchecked(pos)
+    }
+
+    /// Rank of 2-bit `symbol` up to `i` (excluded).
+    ///
+    /// # Safety
+    /// `symbol ≤ 3` and `i ≤ self.len()`.
+    #[inline(always)]
+    pub unsafe fn rank_unchecked(&self, symbol: u8, i: usize) -> usize {
+        debug_assert!(symbol <= 3);
+        self.rank_block(symbol, i) + self.rank_intra_block(symbol, i)
+    }
+
+    /// Ranks of all four symbols up to `i` (excluded).
+    ///
+    /// # Safety
+    /// `i ≤ self.len()`.
+    #[inline(always)]
+    pub unsafe fn rank_all_unchecked(&self, i: usize) -> [usize; 4] {
+        let block = i / B_SIZE;
+        let sb_idx = block / BLOCKS_IN_SUPERBLOCK;
+        let block_in_sb = block % BLOCKS_IN_SUPERBLOCK;
+        let block_ranks = if sb_idx < self.superblocks.len() {
+            self.superblocks
+                .get_unchecked(sb_idx)
+                .get_rank_all(block_in_sb)
+        } else {
+            [0; 4]
+        };
+        let intra = self.rank_intra_block_all(i);
+        [
+            block_ranks[0] + intra[0],
+            block_ranks[1] + intra[1],
+            block_ranks[2] + intra[2],
+            block_ranks[3] + intra[3],
+        ]
+    }
+
+    /// Select: position of the `i`-th occurrence of `symbol` (0-based).
+    pub fn select(&self, symbol: u8, i: usize) -> Option<usize> {
+        if symbol > 3 {
+            return None;
+        }
+        let total = unsafe { self.occs_unchecked(symbol) };
+        if total <= i {
+            return None;
+        }
+        let (mut pos, rank) = self.select_block(symbol, i + 1);
+        pos += self.select_intra_block(symbol, i - rank + 1, pos);
+        Some(pos)
+    }
+
+    #[inline(always)]
+    fn rank_block(&self, symbol: u8, i: usize) -> usize {
+        let superblock_index = i / (B_SIZE * BLOCKS_IN_SUPERBLOCK);
+        let block_index = (i / B_SIZE) % BLOCKS_IN_SUPERBLOCK;
+        if superblock_index >= self.superblocks.len() {
+            return 0;
+        }
+        unsafe {
+            self.superblocks
+                .get_unchecked(superblock_index)
+                .get_rank(symbol, block_index)
+        }
+    }
+
+    #[inline(always)]
+    fn rank_intra_block(&self, symbol: u8, i: usize) -> usize {
+        if B_SIZE == 256 {
+            let data_line_id = i >> 8;
+            let offset = i & 255;
+            return if let Some(d) = self.data.get(data_line_id) {
+                unsafe { d.rank_unchecked(symbol, offset) }
+            } else {
+                0
+            };
+        }
+        // B_SIZE == 512
+        let block_id = i >> 9;
+        let offset_in_block = i & 511;
+        let offset_in_first = if offset_in_block <= 256 {
+            offset_in_block
+        } else {
+            256
+        };
+        let mut rank = if let Some(d) = self.data.get(block_id * 2) {
+            unsafe { d.rank_unchecked(symbol, offset_in_first) }
+        } else {
+            0
+        };
+        if offset_in_block > 256 {
+            rank += if let Some(d) = self.data.get(block_id * 2 + 1) {
+                unsafe { d.rank_unchecked(symbol, offset_in_block - 256) }
+            } else {
+                0
+            };
+        }
+        rank
+    }
+
+    #[inline(always)]
+    fn rank_intra_block_all(&self, i: usize) -> [usize; 4] {
+        if B_SIZE == 256 {
+            let data_line_id = i >> 8;
+            let offset = i & 255;
+            return if let Some(d) = self.data.get(data_line_id) {
+                unsafe { d.rank_all_unchecked(offset) }
+            } else {
+                [0; 4]
+            };
+        }
+        let block_id = i >> 9;
+        let offset_in_block = i & 511;
+        let offset_in_first = if offset_in_block <= 256 {
+            offset_in_block
+        } else {
+            256
+        };
+        let mut ranks = if let Some(d) = self.data.get(block_id * 2) {
+            unsafe { d.rank_all_unchecked(offset_in_first) }
+        } else {
+            [0; 4]
+        };
+        if offset_in_block > 256 {
+            let second = if let Some(d) = self.data.get(block_id * 2 + 1) {
+                unsafe { d.rank_all_unchecked(offset_in_block - 256) }
+            } else {
+                [0; 4]
+            };
+            for s in 0..4 {
+                ranks[s] += second[s];
+            }
+        }
+        ranks
+    }
+
+    /// `(block_start_pos, rank_at_block_start)` for the 1-based `i`-th occurrence.
+    #[inline]
+    fn select_block(&self, symbol: u8, i: usize) -> (usize, usize) {
+        let samples = self.select_samples[symbol as usize];
+        debug_assert!(!samples.is_empty(), "select samples always have sentinel");
+        let sampled_i = (i - 1) / SELECT_NUM_SAMPLES;
+        let sampled_i = sampled_i.min(samples.len().saturating_sub(2));
+        let mut first_sblock_id = samples[sampled_i] as usize;
+        let last_sblock_id = 1 + samples[sampled_i + 1] as usize;
+
+        let step = ((last_sblock_id - first_sblock_id) as f64).sqrt() as usize + 1;
+
+        while first_sblock_id < last_sblock_id {
+            if self.superblocks[first_sblock_id].get_superblock_counter(symbol) >= i {
+                break;
+            }
+            first_sblock_id += step;
+        }
+        first_sblock_id = first_sblock_id.saturating_sub(step);
+
+        while first_sblock_id < last_sblock_id {
+            if self.superblocks[first_sblock_id].get_superblock_counter(symbol) >= i {
+                break;
+            }
+            first_sblock_id += 1;
+        }
+        first_sblock_id = first_sblock_id.saturating_sub(1);
+
+        let mut position = first_sblock_id * B_SIZE * BLOCKS_IN_SUPERBLOCK;
+        let mut rank = self.superblocks[first_sblock_id].get_superblock_counter(symbol);
+
+        let (block_id, block_rank) =
+            self.superblocks[first_sblock_id].block_predecessor(symbol, i - rank);
+        position += block_id * B_SIZE;
+        rank += block_rank;
+        (position, rank)
+    }
+
+    /// Offset within the block at `pos` of the 1-based residual occurrence `i`.
+    #[inline]
+    fn select_intra_block(&self, symbol: u8, i: usize, pos: usize) -> usize {
+        let line_id = pos >> 8;
+        let mut rem = i - 1;
+
+        // B_SIZE 256 → one DataLine; 512 may need two.
+        let n_lines = if B_SIZE == 256 { 1 } else { 2 };
+        let mut result = 0usize;
+        for j in 0..n_lines {
+            let (word_0, word_1) = unsafe {
+                self.data
+                    .get_unchecked(line_id + j)
+                    .normalize(symbol)
+            };
+            let cnt_0 = word_0.count_ones() as usize;
+            if cnt_0 > rem {
+                return result + select_in_word_u128(word_0, rem as u64) as usize;
+            }
+            rem -= cnt_0;
+            result += 128;
+            let cnt_1 = word_1.count_ones() as usize;
+            if cnt_1 > rem {
+                return result + select_in_word_u128(word_1, rem as u64) as usize;
+            }
+            rem -= cnt_1;
+            result += 128;
+        }
+        0
+    }
+}
+
+impl<const B_SIZE: usize> AccessQuad for RSQVectorView<'_, B_SIZE> {
+    #[inline]
+    fn get(&self, i: usize) -> Option<u8> {
+        if i >= self.len() {
+            return None;
+        }
+        Some(unsafe { self.get_unchecked(i) })
+    }
+
+    #[inline]
+    unsafe fn get_unchecked(&self, i: usize) -> u8 {
+        RSQVectorView::get_unchecked(self, i)
+    }
+}
+
+impl<const B_SIZE: usize> RankQuad for RSQVectorView<'_, B_SIZE> {
+    #[inline]
+    fn rank(&self, symbol: u8, i: usize) -> Option<usize> {
+        if symbol > 3 || i > self.len() {
+            return None;
+        }
+        Some(unsafe { self.rank_unchecked(symbol, i) })
+    }
+
+    #[inline]
+    unsafe fn rank_unchecked(&self, symbol: u8, i: usize) -> usize {
+        RSQVectorView::rank_unchecked(self, symbol, i)
+    }
+
+    #[inline]
+    unsafe fn rank_all_unchecked(&self, i: usize) -> [usize; 4] {
+        RSQVectorView::rank_all_unchecked(self, i)
+    }
+}

--- a/src/bytes/level.rs
+++ b/src/bytes/level.rs
@@ -46,16 +46,16 @@ impl LevelDir {
         let n_superblocks = get_u32(buf, &mut o);
         let _pad1 = get_u32(buf, &mut o);
         let mut off_sel = [0u64; 4];
-        for i in 0..4 {
-            off_sel[i] = get_u64(buf, &mut o);
+        for slot in &mut off_sel {
+            *slot = get_u64(buf, &mut o);
         }
         let mut n_sel = [0u32; 4];
-        for i in 0..4 {
-            n_sel[i] = get_u32(buf, &mut o);
+        for slot in &mut n_sel {
+            *slot = get_u32(buf, &mut o);
         }
         let mut n_occs_smaller = [0u64; 5];
-        for i in 0..5 {
-            n_occs_smaller[i] = get_u64(buf, &mut o);
+        for slot in &mut n_occs_smaller {
+            *slot = get_u64(buf, &mut o);
         }
         debug_assert_eq!(o, LEVEL_DIR_SIZE);
         Ok(Self {
@@ -127,7 +127,9 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
     pub(crate) fn from_dir(bytes: &'a [u8], dir: &LevelDir) -> Result<Self, LayoutError> {
         debug_assert!(B_SIZE == 256 || B_SIZE == 512);
 
-        if dir.off_data as usize % 64 != 0 || dir.off_superblocks as usize % 64 != 0 {
+        if !(dir.off_data as usize).is_multiple_of(64)
+            || !(dir.off_superblocks as usize).is_multiple_of(64)
+        {
             return Err(LayoutError::Misaligned);
         }
 
@@ -156,7 +158,7 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
         let superblocks = cast_slice::<SuperblockPlain>(&bytes[sb_off..sb_off + sb_bytes])?;
 
         let mut select_samples: [&'a [u32]; 4] = [&[]; 4];
-        for s in 0..4 {
+        for (s, sample_slot) in select_samples.iter_mut().enumerate() {
             let n_sel = dir.n_sel[s] as usize;
             let off = dir.off_sel[s] as usize;
             let need = n_sel
@@ -166,12 +168,12 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
                 return Err(LayoutError::Truncated);
             }
             // u32 LE samples: 4-byte aligned offsets in a 64-aligned base → cast ok.
-            select_samples[s] = cast_slice::<u32>(&bytes[off..off + need])?;
+            *sample_slot = cast_slice::<u32>(&bytes[off..off + need])?;
         }
 
         let n_occs_smaller: [usize; 5] = std::array::from_fn(|i| dir.n_occs_smaller[i] as usize);
         let position_bits = dir.position_bits as usize;
-        if position_bits % 2 != 0 {
+        if !position_bits.is_multiple_of(2) {
             return Err(LayoutError::Inconsistent {
                 detail: "position_bits must be even",
             });
@@ -233,6 +235,9 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
     }
 
     /// Occurrences of all symbols strictly smaller than `symbol` (0..3).
+    ///
+    /// # Safety
+    /// `symbol` must be `≤ 3`.
     #[inline(always)]
     pub unsafe fn occs_smaller_unchecked(&self, symbol: u8) -> usize {
         debug_assert!(symbol <= 3);
@@ -240,6 +245,9 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
     }
 
     /// Total occurrences of `symbol` (0..3) on this level.
+    ///
+    /// # Safety
+    /// `symbol` must be `≤ 3`.
     #[inline(always)]
     pub unsafe fn occs_unchecked(&self, symbol: u8) -> usize {
         debug_assert!(symbol <= 3);

--- a/src/bytes/level.rs
+++ b/src/bytes/level.rs
@@ -183,6 +183,82 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
                 detail: "position_bits exceeds data capacity",
             });
         }
+        let len = position_bits >> 1;
+        if n_occs_smaller[0] != 0
+            || n_occs_smaller[4] != len
+            || n_occs_smaller.windows(2).any(|pair| pair[0] > pair[1])
+        {
+            return Err(LayoutError::Inconsistent {
+                detail: "child offsets must be monotone from zero through the level length",
+            });
+        }
+
+        let expected_superblocks =
+            (len + B_SIZE * BLOCKS_IN_SUPERBLOCK) / (B_SIZE * BLOCKS_IN_SUPERBLOCK);
+        if n_sb != expected_superblocks {
+            return Err(LayoutError::Inconsistent {
+                detail: "superblock count does not match the level length",
+            });
+        }
+        let last_superblock = n_sb.checked_sub(1).ok_or(LayoutError::Inconsistent {
+            detail: "non-empty level must contain a superblock",
+        })?;
+        for symbol in 0..4 {
+            let samples = select_samples[symbol];
+            let occurrences = n_occs_smaller[symbol + 1] - n_occs_smaller[symbol];
+            let expected_samples = if occurrences == 0 {
+                2
+            } else {
+                (occurrences - 1) / SELECT_NUM_SAMPLES + 2
+            };
+            if samples.len() != expected_samples
+                || samples.first().copied() != Some(0)
+                || samples.last().copied() != Some(last_superblock as u32)
+                || samples.windows(2).any(|pair| pair[0] > pair[1])
+                || samples
+                    .iter()
+                    .any(|sample| *sample as usize > last_superblock)
+            {
+                return Err(LayoutError::Inconsistent {
+                    detail: "select samples do not match the level occurrence counts",
+                });
+            }
+        }
+        for symbol in 0..4u8 {
+            let mut previous = 0usize;
+            for (index, superblock) in superblocks.iter().enumerate() {
+                let prefix = superblock.get_superblock_counter(symbol);
+                if prefix < previous || prefix > len {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "superblock rank counters must be monotone and in bounds",
+                    });
+                }
+                if index > 0 && prefix - previous > B_SIZE * BLOCKS_IN_SUPERBLOCK {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "superblock rank delta exceeds superblock capacity",
+                    });
+                }
+                let mut previous_block = 0usize;
+                let symbols_in_superblock = len
+                    .saturating_sub(index * B_SIZE * BLOCKS_IN_SUPERBLOCK)
+                    .min(B_SIZE * BLOCKS_IN_SUPERBLOCK);
+                let valid_blocks = if symbols_in_superblock == B_SIZE * BLOCKS_IN_SUPERBLOCK {
+                    BLOCKS_IN_SUPERBLOCK
+                } else {
+                    (symbols_in_superblock / B_SIZE + 1).min(BLOCKS_IN_SUPERBLOCK)
+                };
+                for block in 0..valid_blocks {
+                    let rank = superblock.get_block_counter(symbol, block);
+                    if rank < previous_block || rank > symbols_in_superblock {
+                        return Err(LayoutError::Inconsistent {
+                            detail: "block rank counters must be monotone and in bounds",
+                        });
+                    }
+                    previous_block = rank;
+                }
+                previous = prefix;
+            }
+        }
 
         Ok(Self {
             data,
@@ -310,9 +386,9 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
         if total <= i {
             return None;
         }
-        let (mut pos, rank) = self.select_block(symbol, i + 1);
-        pos += self.select_intra_block(symbol, i - rank + 1, pos);
-        Some(pos)
+        let (mut pos, rank) = self.select_block(symbol, i + 1)?;
+        pos += self.select_intra_block(symbol, i.checked_sub(rank)? + 1, pos)?;
+        (pos < self.len()).then_some(pos)
     }
 
     #[inline(always)]
@@ -401,18 +477,21 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
 
     /// `(block_start_pos, rank_at_block_start)` for the 1-based `i`-th occurrence.
     #[inline]
-    fn select_block(&self, symbol: u8, i: usize) -> (usize, usize) {
+    fn select_block(&self, symbol: u8, i: usize) -> Option<(usize, usize)> {
         let samples = self.select_samples[symbol as usize];
-        debug_assert!(!samples.is_empty(), "select samples always have sentinel");
         let sampled_i = (i - 1) / SELECT_NUM_SAMPLES;
-        let sampled_i = sampled_i.min(samples.len().saturating_sub(2));
-        let mut first_sblock_id = samples[sampled_i] as usize;
-        let last_sblock_id = 1 + samples[sampled_i + 1] as usize;
+        let mut first_sblock_id = *samples.get(sampled_i)? as usize;
+        let last_sblock_id = 1usize.checked_add(*samples.get(sampled_i + 1)? as usize)?;
 
         let step = ((last_sblock_id - first_sblock_id) as f64).sqrt() as usize + 1;
 
         while first_sblock_id < last_sblock_id {
-            if self.superblocks[first_sblock_id].get_superblock_counter(symbol) >= i {
+            if self
+                .superblocks
+                .get(first_sblock_id)?
+                .get_superblock_counter(symbol)
+                >= i
+            {
                 break;
             }
             first_sblock_id += step;
@@ -420,7 +499,12 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
         first_sblock_id = first_sblock_id.saturating_sub(step);
 
         while first_sblock_id < last_sblock_id {
-            if self.superblocks[first_sblock_id].get_superblock_counter(symbol) >= i {
+            if self
+                .superblocks
+                .get(first_sblock_id)?
+                .get_superblock_counter(symbol)
+                >= i
+            {
                 break;
             }
             first_sblock_id += 1;
@@ -428,18 +512,18 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
         first_sblock_id = first_sblock_id.saturating_sub(1);
 
         let mut position = first_sblock_id * B_SIZE * BLOCKS_IN_SUPERBLOCK;
-        let mut rank = self.superblocks[first_sblock_id].get_superblock_counter(symbol);
+        let superblock = self.superblocks.get(first_sblock_id)?;
+        let mut rank = superblock.get_superblock_counter(symbol);
 
-        let (block_id, block_rank) =
-            self.superblocks[first_sblock_id].block_predecessor(symbol, i - rank);
+        let (block_id, block_rank) = superblock.block_predecessor(symbol, i.checked_sub(rank)?);
         position += block_id * B_SIZE;
         rank += block_rank;
-        (position, rank)
+        Some((position, rank))
     }
 
     /// Offset within the block at `pos` of the 1-based residual occurrence `i`.
     #[inline]
-    fn select_intra_block(&self, symbol: u8, i: usize, pos: usize) -> usize {
+    fn select_intra_block(&self, symbol: u8, i: usize, pos: usize) -> Option<usize> {
         let line_id = pos >> 8;
         let mut rem = i - 1;
 
@@ -447,22 +531,21 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
         let n_lines = if B_SIZE == 256 { 1 } else { 2 };
         let mut result = 0usize;
         for j in 0..n_lines {
-            let (word_0, word_1) =
-                unsafe { self.data.get_unchecked(line_id + j).normalize(symbol) };
+            let (word_0, word_1) = self.data.get(line_id + j)?.normalize(symbol);
             let cnt_0 = word_0.count_ones() as usize;
             if cnt_0 > rem {
-                return result + select_in_word_u128(word_0, rem as u64) as usize;
+                return Some(result + select_in_word_u128(word_0, rem as u64) as usize);
             }
             rem -= cnt_0;
             result += 128;
             let cnt_1 = word_1.count_ones() as usize;
             if cnt_1 > rem {
-                return result + select_in_word_u128(word_1, rem as u64) as usize;
+                return Some(result + select_in_word_u128(word_1, rem as u64) as usize);
             }
             rem -= cnt_1;
             result += 128;
         }
-        0
+        None
     }
 }
 

--- a/src/bytes/level.rs
+++ b/src/bytes/level.rs
@@ -203,6 +203,12 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
         let last_superblock = n_sb.checked_sub(1).ok_or(LayoutError::Inconsistent {
             detail: "non-empty level must contain a superblock",
         })?;
+        // Select samples: the builder records the superblock of every
+        // `SELECT_NUM_SAMPLES`-th occurrence (by 0-based occurrence index),
+        // then appends a sentinel equal to the last superblock index.
+        // Empty symbols get a filler sample of 0 plus the sentinel so
+        // `select_block` can always index `samples[k]` / `samples[k+1]`.
+        // Sample 0 is the superblock of the first occurrence (may be > 0).
         for symbol in 0..4 {
             let samples = select_samples[symbol];
             let occurrences = n_occs_smaller[symbol + 1] - n_occs_smaller[symbol];
@@ -212,7 +218,6 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
                 (occurrences - 1) / SELECT_NUM_SAMPLES + 2
             };
             if samples.len() != expected_samples
-                || samples.first().copied() != Some(0)
                 || samples.last().copied() != Some(last_superblock as u32)
                 || samples.windows(2).any(|pair| pair[0] > pair[1])
                 || samples
@@ -223,7 +228,31 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
                     detail: "select samples do not match the level occurrence counts",
                 });
             }
+            // Empty symbols: only the filler+sentinel shape is checked above.
+            // Non-empty: each non-sentinel sample k must be the superblock that
+            // contains occurrence index `k * SELECT_NUM_SAMPLES`.
+            if occurrences == 0 {
+                continue;
+            }
+            let n_non_sentinel = samples.len() - 1;
+            for (k, &sample) in samples.iter().take(n_non_sentinel).enumerate() {
+                let target = k * SELECT_NUM_SAMPLES;
+                let sb = sample as usize;
+                if superblocks[sb].get_superblock_counter(symbol as u8) > target {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "select sample superblock rank exceeds the sampled occurrence",
+                    });
+                }
+                if sb + 1 < n_sb
+                    && superblocks[sb + 1].get_superblock_counter(symbol as u8) <= target
+                {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "select sample superblock is before the sampled occurrence",
+                    });
+                }
+            }
         }
+
         for symbol in 0..4u8 {
             let mut previous = 0usize;
             for (index, superblock) in superblocks.iter().enumerate() {

--- a/src/bytes/level.rs
+++ b/src/bytes/level.rs
@@ -145,7 +145,8 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
         {
             return Err(LayoutError::Truncated);
         }
-        let data = cast_slice::<DataLine>(&bytes[data_off..data_off + data_bytes])?;
+        // SAFETY: DataLine is repr(C), contains only integers, and accepts every bit pattern.
+        let data = unsafe { cast_slice::<DataLine>(&bytes[data_off..data_off + data_bytes])? };
 
         let sb_off = dir.off_superblocks as usize;
         let n_sb = dir.n_superblocks as usize;
@@ -155,7 +156,9 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
         if sb_off.checked_add(sb_bytes).ok_or(LayoutError::Truncated)? > bytes.len() {
             return Err(LayoutError::Truncated);
         }
-        let superblocks = cast_slice::<SuperblockPlain>(&bytes[sb_off..sb_off + sb_bytes])?;
+        // SAFETY: SuperblockPlain is repr(C), contains only integers, and accepts every bit pattern.
+        let superblocks =
+            unsafe { cast_slice::<SuperblockPlain>(&bytes[sb_off..sb_off + sb_bytes])? };
 
         let mut select_samples: [&'a [u32]; 4] = [&[]; 4];
         for (s, sample_slot) in select_samples.iter_mut().enumerate() {
@@ -168,7 +171,8 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
                 return Err(LayoutError::Truncated);
             }
             // u32 LE samples: 4-byte aligned offsets in a 64-aligned base → cast ok.
-            *sample_slot = cast_slice::<u32>(&bytes[off..off + need])?;
+            // SAFETY: every u32 bit pattern is valid.
+            *sample_slot = unsafe { cast_slice::<u32>(&bytes[off..off + need])? };
         }
 
         let n_occs_smaller: [usize; 5] = std::array::from_fn(|i| dir.n_occs_smaller[i] as usize);
@@ -203,6 +207,102 @@ impl<'a, const B_SIZE: usize> RSQVectorView<'a, B_SIZE> {
         let last_superblock = n_sb.checked_sub(1).ok_or(LayoutError::Inconsistent {
             detail: "non-empty level must contain a superblock",
         })?;
+
+        // Recompute every persisted rank counter from the encoded symbols.
+        // Monotonic/in-range metadata alone is insufficient because safe tree
+        // traversal feeds these counters into unchecked accesses on the next
+        // level.
+        let superblock_size = B_SIZE * BLOCKS_IN_SUPERBLOCK;
+        let mut totals = [0usize; 4];
+        let mut superblock_base = [0usize; 4];
+        let mut block_start = 0usize;
+        loop {
+            if block_start.is_multiple_of(superblock_size) {
+                let superblock_index = block_start / superblock_size;
+                let Some(superblock) = superblocks.get(superblock_index) else {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "missing superblock at a sequence boundary",
+                    });
+                };
+                for symbol in 0..4u8 {
+                    if superblock.get_superblock_counter(symbol) != totals[symbol as usize] {
+                        return Err(LayoutError::Inconsistent {
+                            detail: "superblock rank counter disagrees with encoded symbols",
+                        });
+                    }
+                }
+                superblock_base = totals;
+            }
+            if block_start.is_multiple_of(B_SIZE) {
+                let superblock_index = block_start / superblock_size;
+                let block_index = (block_start / B_SIZE) % BLOCKS_IN_SUPERBLOCK;
+                let Some(superblock) = superblocks.get(superblock_index) else {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "missing superblock for block counter",
+                    });
+                };
+                for symbol in 0..4u8 {
+                    if superblock.get_block_counter(symbol, block_index)
+                        != totals[symbol as usize] - superblock_base[symbol as usize]
+                    {
+                        return Err(LayoutError::Inconsistent {
+                            detail: "block rank counter disagrees with encoded symbols",
+                        });
+                    }
+                }
+            }
+            if block_start == len {
+                break;
+            }
+
+            let block_end = block_start.saturating_add(B_SIZE).min(len);
+            let mut position = block_start;
+            while position < block_end {
+                let Some(line) = data.get(position >> 8) else {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "level data is shorter than its position cursor",
+                    });
+                };
+                let line_start = position & 255;
+                let line_end = block_end.min((position | 255).saturating_add(1));
+                let line_len = line_end - position;
+                // SAFETY: `line_start + line_len <= 256` by construction.
+                let end_ranks = unsafe { line.rank_all_unchecked(line_start + line_len) };
+                let start_ranks = if line_start == 0 {
+                    [0; 4]
+                } else {
+                    // SAFETY: `line_start < 256` by construction.
+                    unsafe { line.rank_all_unchecked(line_start) }
+                };
+                for symbol in 0..4 {
+                    totals[symbol] += end_ranks[symbol] - start_ranks[symbol];
+                }
+                position = line_end;
+            }
+            block_start = block_end;
+        }
+        let current_superblock = len / superblock_size;
+        let sentinel_block = (len / B_SIZE) % BLOCKS_IN_SUPERBLOCK + 1;
+        if sentinel_block < BLOCKS_IN_SUPERBLOCK {
+            let superblock = &superblocks[current_superblock];
+            for symbol in 0..4u8 {
+                if superblock.get_block_counter(symbol, sentinel_block)
+                    != totals[symbol as usize] - superblock_base[symbol as usize]
+                {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "sentinel block counter disagrees with encoded symbols",
+                    });
+                }
+            }
+        }
+        for symbol in 0..4 {
+            if n_occs_smaller[symbol + 1] - n_occs_smaller[symbol] != totals[symbol] {
+                return Err(LayoutError::Inconsistent {
+                    detail: "child offsets disagree with encoded symbol counts",
+                });
+            }
+        }
+
         // Select samples: the builder records the superblock of every
         // `SELECT_NUM_SAMPLES`-th occurrence (by 0-based occurrence index),
         // then appends a sentinel equal to the last superblock index.

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -14,10 +14,10 @@
 //! ([`LayoutError::PrefetchNotSupported`]).
 
 mod error;
-mod util;
-mod qwtb;
 mod hqwb;
 mod level;
+mod qwtb;
+mod util;
 mod view;
 
 pub use error::LayoutError;
@@ -28,14 +28,8 @@ pub use view::{AlignedBytes, HqwtView, QwtView};
 
 #[allow(unused_imports)] // cast_slice_mut / write_slice kept for future writers
 pub(crate) use util::{
-    align_up, cast_slice, cast_slice_mut, copy_pod_slice, ensure_le, write_slice,
+    align_up, cast_slice, cast_slice_mut, checked_region, copy_pod_slice, ensure_le, write_slice,
 };
-
-
-
-
-
-
 
 /// Magic for a plain quad wavelet tree byte blob.
 pub const QWTB_MAGIC: &[u8; 4] = b"QWTB";
@@ -56,7 +50,6 @@ pub const LEVEL_DIR_SIZE: usize = 128;
 /// Bytes per HQWT level directory entry (`LEVEL_DIR_SIZE` + `level_len` u64).
 pub const HQWT_LEVEL_DIR_SIZE: usize = LEVEL_DIR_SIZE + 8;
 
-
 /// Flag bit0: block size is 512 (else 256).
 pub const FLAG_B512: u8 = 0b0000_0001;
 /// Flag bit1: prefetch support present (rejected in v1).
@@ -64,4 +57,3 @@ pub const FLAG_PREFETCH: u8 = 0b0000_0010;
 
 #[cfg(test)]
 mod from_parts_tests;
-

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -17,15 +17,21 @@ mod error;
 mod util;
 mod qwtb;
 mod hqwb;
+mod level;
+mod view;
 
 pub use error::LayoutError;
 pub use hqwb::{hqwt256_from_bytes, hqwt256_to_bytes, hqwt512_from_bytes, hqwt512_to_bytes};
+pub use level::RSQVectorView;
 pub use qwtb::{qwt256_from_bytes, qwt256_to_bytes, qwt512_from_bytes, qwt512_to_bytes};
+pub use view::{AlignedBytes, HqwtView, QwtView};
 
-#[allow(unused_imports)] // cast_slice_mut / write_slice used by HQWB
+#[allow(unused_imports)] // cast_slice_mut / write_slice kept for future writers
 pub(crate) use util::{
     align_up, cast_slice, cast_slice_mut, copy_pod_slice, ensure_le, write_slice,
 };
+
+
 
 
 

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -1,0 +1,46 @@
+//! Zero-copy byte I/O for quad wavelet trees.
+//!
+//! This module provides a canonical little-endian on-disk / in-memory byte
+//! layout for [`crate::QWaveletTree`] (`QWTB`) and [`crate::HuffQWaveletTree`]
+//! (`HQWB`), together with:
+//!
+//! - owned round-trips: `to_bytes` / `from_bytes`
+//! - borrowed zero-copy views: [`QwtView`] / [`HqwtView`] over a caller-provided
+//!   `&[u8]` (the caller owns any `mmap`; this crate never depends on one)
+//!
+//! No feature flags. No new dependencies. The existing serde path is unchanged.
+//!
+//! Prefetch-augmented trees (`*Pfs`) are rejected in v1
+//! ([`LayoutError::PrefetchNotSupported`]).
+
+mod error;
+mod util;
+
+pub use error::LayoutError;
+// Re-exported for the upcoming QWTB/HQWB container (to_bytes/from_bytes).
+#[allow(unused_imports)]
+pub(crate) use util::{align_up, cast_slice, cast_slice_mut, ensure_le, write_slice};
+
+
+/// Magic for a plain quad wavelet tree byte blob.
+pub const QWTB_MAGIC: &[u8; 4] = b"QWTB";
+/// Magic for a Huffman quad wavelet tree byte blob.
+pub const HQWB_MAGIC: &[u8; 4] = b"HQWB";
+/// Container format version.
+pub const FORMAT_VERSION: u16 = 1;
+
+/// Header size shared by `QWTB` and `HQWB` (bytes before the level directory).
+pub const HEADER_SIZE: usize = 32;
+/// Bytes per plain-QWT level directory entry.
+pub const LEVEL_DIR_SIZE: usize = 96;
+/// Bytes per HQWT level directory entry (`LEVEL_DIR_SIZE` + `level_len` u64).
+pub const HQWT_LEVEL_DIR_SIZE: usize = LEVEL_DIR_SIZE + 8;
+
+/// Flag bit0: block size is 512 (else 256).
+pub const FLAG_B512: u8 = 0b0000_0001;
+/// Flag bit1: prefetch support present (rejected in v1).
+pub const FLAG_PREFETCH: u8 = 0b0000_0010;
+
+#[cfg(test)]
+mod from_parts_tests;
+

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -15,11 +15,17 @@
 
 mod error;
 mod util;
+mod qwtb;
 
 pub use error::LayoutError;
-// Re-exported for the upcoming QWTB/HQWB container (to_bytes/from_bytes).
-#[allow(unused_imports)]
-pub(crate) use util::{align_up, cast_slice, cast_slice_mut, ensure_le, write_slice};
+pub use qwtb::{qwt256_from_bytes, qwt256_to_bytes, qwt512_from_bytes, qwt512_to_bytes};
+#[allow(unused_imports)] // cast_slice_mut / write_slice used by HQWB
+pub(crate) use util::{
+    align_up, cast_slice, cast_slice_mut, copy_pod_slice, ensure_le, write_slice,
+};
+
+
+
 
 
 /// Magic for a plain quad wavelet tree byte blob.
@@ -32,9 +38,15 @@ pub const FORMAT_VERSION: u16 = 1;
 /// Header size shared by `QWTB` and `HQWB` (bytes before the level directory).
 pub const HEADER_SIZE: usize = 32;
 /// Bytes per plain-QWT level directory entry.
-pub const LEVEL_DIR_SIZE: usize = 96;
+///
+/// Layout: `off_data u64` + `n_datalines u32` + `pad0 u32` + `position_bits u64`
+/// + `off_superblocks u64` + `n_superblocks u32` + `pad1 u32` + `off_sel[4] u64×4`
+/// + `n_sel[4] u32×4` + `n_occs_smaller[5] u64×5`
+/// = 8+4+4+8+8+4+4+32+16+40 = 128.
+pub const LEVEL_DIR_SIZE: usize = 128;
 /// Bytes per HQWT level directory entry (`LEVEL_DIR_SIZE` + `level_len` u64).
 pub const HQWT_LEVEL_DIR_SIZE: usize = LEVEL_DIR_SIZE + 8;
+
 
 /// Flag bit0: block size is 512 (else 256).
 pub const FLAG_B512: u8 = 0b0000_0001;

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -16,9 +16,12 @@
 mod error;
 mod util;
 mod qwtb;
+mod hqwb;
 
 pub use error::LayoutError;
+pub use hqwb::{hqwt256_from_bytes, hqwt256_to_bytes, hqwt512_from_bytes, hqwt512_to_bytes};
 pub use qwtb::{qwt256_from_bytes, qwt256_to_bytes, qwt512_from_bytes, qwt512_to_bytes};
+
 #[allow(unused_imports)] // cast_slice_mut / write_slice used by HQWB
 pub(crate) use util::{
     align_up, cast_slice, cast_slice_mut, copy_pod_slice, ensure_le, write_slice,

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -42,9 +42,11 @@ pub const FORMAT_VERSION: u16 = 1;
 pub const HEADER_SIZE: usize = 32;
 /// Bytes per plain-QWT level directory entry.
 ///
-/// Layout: `off_data u64` + `n_datalines u32` + `pad0 u32` + `position_bits u64`
-/// + `off_superblocks u64` + `n_superblocks u32` + `pad1 u32` + `off_sel[4] u64×4`
-/// + `n_sel[4] u32×4` + `n_occs_smaller[5] u64×5`
+/// Layout:
+/// - `off_data u64` + `n_datalines u32` + `pad0 u32` + `position_bits u64`
+/// - `off_superblocks u64` + `n_superblocks u32` + `pad1 u32` + `off_sel[4] u64×4`
+/// - `n_sel[4] u32×4` + `n_occs_smaller[5] u64×5`
+///
 /// = 8+4+4+8+8+4+4+32+16+40 = 128.
 pub const LEVEL_DIR_SIZE: usize = 128;
 /// Bytes per HQWT level directory entry (`LEVEL_DIR_SIZE` + `level_len` u64).

--- a/src/bytes/qwtb.rs
+++ b/src/bytes/qwtb.rs
@@ -76,16 +76,16 @@ impl LevelDir {
         let n_superblocks = get_u32(buf, &mut o);
         let _pad1 = get_u32(buf, &mut o);
         let mut off_sel = [0u64; 4];
-        for i in 0..4 {
-            off_sel[i] = get_u64(buf, &mut o);
+        for slot in &mut off_sel {
+            *slot = get_u64(buf, &mut o);
         }
         let mut n_sel = [0u32; 4];
-        for i in 0..4 {
-            n_sel[i] = get_u32(buf, &mut o);
+        for slot in &mut n_sel {
+            *slot = get_u32(buf, &mut o);
         }
         let mut n_occs_smaller = [0u64; 5];
-        for i in 0..5 {
-            n_occs_smaller[i] = get_u64(buf, &mut o);
+        for slot in &mut n_occs_smaller {
+            *slot = get_u64(buf, &mut o);
         }
         Ok(Self {
             off_data,
@@ -351,7 +351,7 @@ where
 
         // Data lines — offsets must be 64-aligned in the format; the source
         // buffer itself need not be (owned path copies into aligned heap).
-        if dir.off_data as usize % 64 != 0 {
+        if !(dir.off_data as usize).is_multiple_of(64) {
             return Err(LayoutError::Misaligned);
         }
         let data_off = dir.off_data as usize;
@@ -361,7 +361,7 @@ where
         let qv = QVector::from_raw_parts(lines, dir.position_bits as usize);
 
         // Superblocks
-        if dir.off_superblocks as usize % 64 != 0 {
+        if !(dir.off_superblocks as usize).is_multiple_of(64) {
             return Err(LayoutError::Misaligned);
         }
         let sb_off = dir.off_superblocks as usize;
@@ -376,7 +376,7 @@ where
 
         // Select samples
         let mut select_samples: [Box<[u32]>; 4] = Default::default();
-        for s in 0..4 {
+        for (s, sample_slot) in select_samples.iter_mut().enumerate() {
             let n_sel = dir.n_sel[s] as usize;
             let off = dir.off_sel[s] as usize;
             let _ = checked_region(off, n_sel, size_of::<u32>(), bytes.len())?;
@@ -385,7 +385,7 @@ where
                 let b = off + i * 4;
                 v.push(u32::from_le_bytes(bytes[b..b + 4].try_into().unwrap()));
             }
-            select_samples[s] = v.into_boxed_slice();
+            *sample_slot = v.into_boxed_slice();
         }
 
         let rs = RSSupportPlain::<B>::from_parts(superblocks, select_samples);

--- a/src/bytes/qwtb.rs
+++ b/src/bytes/qwtb.rs
@@ -134,7 +134,14 @@ fn get_u64(buf: &[u8], o: &mut usize) -> u64 {
     v
 }
 
-/// Serialize a plain QWT256 into a `QWTB` blob.
+/// Serialize a plain [`QWT256`](crate::QWT256) into a `QWTB` blob.
+///
+/// The result is a self-contained little-endian byte vector. The source buffer
+/// for a later [`qwt256_from_bytes`] call need **not** be 64-byte aligned
+/// (the owned path copies POD payloads onto the heap).
+///
+/// # Errors
+/// Returns [`LayoutError::NotLittleEndian`] on big-endian hosts.
 pub fn qwt256_to_bytes<T>(
     tree: &QWaveletTree<T, RSQVector<RSSupportPlain<256>>, false>,
 ) -> Result<Vec<u8>, LayoutError>
@@ -145,7 +152,10 @@ where
     to_bytes_generic::<T, 256>(tree)
 }
 
-/// Serialize a plain QWT512 into a `QWTB` blob.
+/// Serialize a plain [`QWT512`](crate::QWT512) into a `QWTB` blob.
+///
+/// See [`qwt256_to_bytes`] for details; the only difference is the block size
+/// flag (`FLAG_B512`).
 pub fn qwt512_to_bytes<T>(
     tree: &QWaveletTree<T, RSQVector<RSSupportPlain<512>>, false>,
 ) -> Result<Vec<u8>, LayoutError>
@@ -271,7 +281,13 @@ where
     Ok(out)
 }
 
-/// Deserialize a `QWTB` blob into an owned QWT256.
+/// Deserialize a `QWTB` blob into an owned [`QWT256`](crate::QWT256).
+///
+/// Copies POD payloads onto the heap, so `bytes` need not be 64-byte aligned.
+/// For a zero-copy alternative see [`crate::bytes::QwtView`].
+///
+/// # Errors
+/// See [`LayoutError`] — magic/version/flags/alignment/truncation failures.
 pub fn qwt256_from_bytes<T>(
     bytes: &[u8],
 ) -> Result<QWaveletTree<T, RSQVector<RSSupportPlain<256>>, false>, LayoutError>
@@ -283,7 +299,9 @@ where
     from_bytes_generic::<T, 256>(bytes)
 }
 
-/// Deserialize a `QWTB` blob into an owned QWT512.
+/// Deserialize a `QWTB` blob into an owned [`QWT512`](crate::QWT512).
+///
+/// See [`qwt256_from_bytes`].
 pub fn qwt512_from_bytes<T>(
     bytes: &[u8],
 ) -> Result<QWaveletTree<T, RSQVector<RSSupportPlain<512>>, false>, LayoutError>

--- a/src/bytes/qwtb.rs
+++ b/src/bytes/qwtb.rs
@@ -1,6 +1,6 @@
 //! `QWTB` container: owned serialize / deserialize for plain [`QWaveletTree`].
 //!
-//! Layout (little-endian, see `research/PR2_MMAP_API.md`):
+//! Layout (little-endian):
 //!
 //! ```text
 //! [0..4)   magic b"QWTB"
@@ -15,16 +15,14 @@
 //!          then 64-aligned POD payloads per level
 //! ```
 
-
 use super::{
-    align_up, copy_pod_slice, ensure_le, LayoutError, FLAG_B512, FLAG_PREFETCH, FORMAT_VERSION,
-    HEADER_SIZE, LEVEL_DIR_SIZE, QWTB_MAGIC,
+    align_up, checked_region, copy_pod_slice, ensure_le, LayoutError, FLAG_B512, FLAG_PREFETCH,
+    FORMAT_VERSION, HEADER_SIZE, LEVEL_DIR_SIZE, QWTB_MAGIC,
 };
 
-
+use crate::quadwt::{QWaveletTree, RSforWT, WTIndexable};
 use crate::qvector::rs_qvector::{RSQVector, RSSupportPlain, SuperblockPlain};
 use crate::qvector::{DataLine, QVector};
-use crate::quadwt::{QWaveletTree, RSforWT, WTIndexable};
 use num_traits::AsPrimitive;
 use std::mem::size_of;
 
@@ -137,7 +135,9 @@ fn get_u64(buf: &[u8], o: &mut usize) -> u64 {
 }
 
 /// Serialize a plain QWT256 into a `QWTB` blob.
-pub fn qwt256_to_bytes<T>(tree: &QWaveletTree<T, RSQVector<RSSupportPlain<256>>, false>) -> Result<Vec<u8>, LayoutError>
+pub fn qwt256_to_bytes<T>(
+    tree: &QWaveletTree<T, RSQVector<RSSupportPlain<256>>, false>,
+) -> Result<Vec<u8>, LayoutError>
 where
     T: WTIndexable,
     usize: AsPrimitive<T>,
@@ -146,7 +146,9 @@ where
 }
 
 /// Serialize a plain QWT512 into a `QWTB` blob.
-pub fn qwt512_to_bytes<T>(tree: &QWaveletTree<T, RSQVector<RSSupportPlain<512>>, false>) -> Result<Vec<u8>, LayoutError>
+pub fn qwt512_to_bytes<T>(
+    tree: &QWaveletTree<T, RSQVector<RSSupportPlain<512>>, false>,
+) -> Result<Vec<u8>, LayoutError>
 where
     T: WTIndexable,
     usize: AsPrimitive<T>,
@@ -211,7 +213,6 @@ where
         });
     }
 
-
     let mut out = vec![0u8; cursor];
 
     // Header
@@ -246,16 +247,14 @@ where
         let off = dir.off_data as usize;
         let nbytes = dir.n_datalines as usize * size_of::<DataLine>();
         // SAFETY / layout: DataLine is repr(C, align(64)); we write raw bytes.
-        let src = unsafe {
-            std::slice::from_raw_parts(qv.data_lines().as_ptr() as *const u8, nbytes)
-        };
+        let src =
+            unsafe { std::slice::from_raw_parts(qv.data_lines().as_ptr() as *const u8, nbytes) };
         out[off..off + nbytes].copy_from_slice(src);
 
         let off = dir.off_superblocks as usize;
         let nbytes = dir.n_superblocks as usize * size_of::<SuperblockPlain>();
-        let src = unsafe {
-            std::slice::from_raw_parts(rs.superblocks().as_ptr() as *const u8, nbytes)
-        };
+        let src =
+            unsafe { std::slice::from_raw_parts(rs.superblocks().as_ptr() as *const u8, nbytes) };
         out[off..off + nbytes].copy_from_slice(src);
 
         for s in 0..4 {
@@ -272,9 +271,10 @@ where
     Ok(out)
 }
 
-
 /// Deserialize a `QWTB` blob into an owned QWT256.
-pub fn qwt256_from_bytes<T>(bytes: &[u8]) -> Result<QWaveletTree<T, RSQVector<RSSupportPlain<256>>, false>, LayoutError>
+pub fn qwt256_from_bytes<T>(
+    bytes: &[u8],
+) -> Result<QWaveletTree<T, RSQVector<RSSupportPlain<256>>, false>, LayoutError>
 where
     T: WTIndexable,
     usize: AsPrimitive<T>,
@@ -284,7 +284,9 @@ where
 }
 
 /// Deserialize a `QWTB` blob into an owned QWT512.
-pub fn qwt512_from_bytes<T>(bytes: &[u8]) -> Result<QWaveletTree<T, RSQVector<RSSupportPlain<512>>, false>, LayoutError>
+pub fn qwt512_from_bytes<T>(
+    bytes: &[u8],
+) -> Result<QWaveletTree<T, RSQVector<RSSupportPlain<512>>, false>, LayoutError>
 where
     T: WTIndexable,
     usize: AsPrimitive<T>,
@@ -353,11 +355,9 @@ where
             return Err(LayoutError::Misaligned);
         }
         let data_off = dir.off_data as usize;
-        let data_bytes = dir.n_datalines as usize * size_of::<DataLine>();
-        if data_off + data_bytes > bytes.len() {
-            return Err(LayoutError::Truncated);
-        }
-        let lines = copy_pod_slice::<DataLine>(&bytes[data_off..], dir.n_datalines as usize)?;
+        let n_datalines = dir.n_datalines as usize;
+        let _ = checked_region(data_off, n_datalines, size_of::<DataLine>(), bytes.len())?;
+        let lines = copy_pod_slice::<DataLine>(&bytes[data_off..], n_datalines)?;
         let qv = QVector::from_raw_parts(lines, dir.position_bits as usize);
 
         // Superblocks
@@ -365,23 +365,21 @@ where
             return Err(LayoutError::Misaligned);
         }
         let sb_off = dir.off_superblocks as usize;
-        let sb_bytes = dir.n_superblocks as usize * size_of::<SuperblockPlain>();
-        if sb_off + sb_bytes > bytes.len() {
-            return Err(LayoutError::Truncated);
-        }
-        let superblocks =
-            copy_pod_slice::<SuperblockPlain>(&bytes[sb_off..], dir.n_superblocks as usize)?;
-
+        let n_superblocks = dir.n_superblocks as usize;
+        let _ = checked_region(
+            sb_off,
+            n_superblocks,
+            size_of::<SuperblockPlain>(),
+            bytes.len(),
+        )?;
+        let superblocks = copy_pod_slice::<SuperblockPlain>(&bytes[sb_off..], n_superblocks)?;
 
         // Select samples
         let mut select_samples: [Box<[u32]>; 4] = Default::default();
         for s in 0..4 {
             let n_sel = dir.n_sel[s] as usize;
             let off = dir.off_sel[s] as usize;
-            let end = off + n_sel * 4;
-            if end > bytes.len() {
-                return Err(LayoutError::Truncated);
-            }
+            let _ = checked_region(off, n_sel, size_of::<u32>(), bytes.len())?;
             let mut v = Vec::with_capacity(n_sel);
             for i in 0..n_sel {
                 let b = off + i * 4;
@@ -404,7 +402,6 @@ where
     QWaveletTree::from_parts(n, n_levels, sigma, qvs)
 }
 
-
 // Silence "RSforWT unused" when only used via bound on QWaveletTree methods.
 const _: fn() = || {
     fn assert_rsforwt<T: RSforWT>() {}
@@ -414,7 +411,7 @@ const _: fn() = || {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{AccessUnsigned, QWT256, RankUnsigned, SelectUnsigned};
+    use crate::{AccessUnsigned, RankUnsigned, SelectUnsigned, QWT256};
 
     #[test]
     fn qwtb_roundtrip_get_rank_select() {
@@ -433,7 +430,11 @@ mod tests {
         }
         for &sym in &[0u32, 1, 5, 64, 127] {
             for i in (0..=data.len()).step_by(31) {
-                assert_eq!(original.rank(sym, i), rebuilt.rank(sym, i), "rank({sym},{i})");
+                assert_eq!(
+                    original.rank(sym, i),
+                    rebuilt.rank(sym, i),
+                    "rank({sym},{i})"
+                );
             }
             if let Some(cnt) = original.rank(sym, data.len()) {
                 for k in 0..cnt.min(3) {
@@ -459,7 +460,6 @@ mod tests {
         assert_eq!(rebuilt.n_levels(), 0);
     }
 
-
     #[test]
     fn qwtb_bad_magic() {
         let mut bytes = qwt256_to_bytes(&QWT256::from(vec![1u32, 2, 3])).unwrap();
@@ -471,6 +471,9 @@ mod tests {
     #[test]
     fn qwtb_truncated() {
         let err = qwt256_from_bytes::<u32>(&[0u8; 8]).unwrap_err();
-        assert!(matches!(err, LayoutError::BadMagic | LayoutError::Truncated));
+        assert!(matches!(
+            err,
+            LayoutError::BadMagic | LayoutError::Truncated
+        ));
     }
 }

--- a/src/bytes/qwtb.rs
+++ b/src/bytes/qwtb.rs
@@ -1,0 +1,476 @@
+//! `QWTB` container: owned serialize / deserialize for plain [`QWaveletTree`].
+//!
+//! Layout (little-endian, see `research/PR2_MMAP_API.md`):
+//!
+//! ```text
+//! [0..4)   magic b"QWTB"
+//! [4..6)   version u16 = 1
+//! [6]      flags u8 (bit0 = B_SIZE=512, bit1 = prefetch — rejected)
+//! [7]      t_width u8 = size_of::<T>()
+//! [8..16)  n u64
+//! [16..24) sigma_raw u64 (zero-extended)
+//! [24..26) n_levels u16
+//! [26..32) reserved 0
+//! [32..)   level directory: n_levels × 128 B
+//!          then 64-aligned POD payloads per level
+//! ```
+
+
+use super::{
+    align_up, copy_pod_slice, ensure_le, LayoutError, FLAG_B512, FLAG_PREFETCH, FORMAT_VERSION,
+    HEADER_SIZE, LEVEL_DIR_SIZE, QWTB_MAGIC,
+};
+
+
+use crate::qvector::rs_qvector::{RSQVector, RSSupportPlain, SuperblockPlain};
+use crate::qvector::{DataLine, QVector};
+use crate::quadwt::{QWaveletTree, RSforWT, WTIndexable};
+use num_traits::AsPrimitive;
+use std::mem::size_of;
+
+/// One level directory entry (128 bytes, packed LE).
+
+#[derive(Clone, Debug)]
+struct LevelDir {
+    off_data: u64,
+    n_datalines: u32,
+    position_bits: u64,
+    off_superblocks: u64,
+    n_superblocks: u32,
+    off_sel: [u64; 4],
+    n_sel: [u32; 4],
+    n_occs_smaller: [u64; 5],
+}
+
+impl LevelDir {
+    fn write(&self, out: &mut [u8]) {
+        debug_assert_eq!(out.len(), LEVEL_DIR_SIZE);
+        let mut o = 0;
+        put_u64(out, &mut o, self.off_data);
+        put_u32(out, &mut o, self.n_datalines);
+        put_u32(out, &mut o, 0); // pad0
+        put_u64(out, &mut o, self.position_bits);
+        put_u64(out, &mut o, self.off_superblocks);
+        put_u32(out, &mut o, self.n_superblocks);
+        put_u32(out, &mut o, 0); // pad1
+        for i in 0..4 {
+            put_u64(out, &mut o, self.off_sel[i]);
+        }
+        for i in 0..4 {
+            put_u32(out, &mut o, self.n_sel[i]);
+        }
+        for i in 0..5 {
+            put_u64(out, &mut o, self.n_occs_smaller[i]);
+        }
+        debug_assert_eq!(o, LEVEL_DIR_SIZE);
+    }
+
+    fn read(buf: &[u8]) -> Result<Self, LayoutError> {
+        if buf.len() < LEVEL_DIR_SIZE {
+            return Err(LayoutError::Truncated);
+        }
+        let mut o = 0;
+        let off_data = get_u64(buf, &mut o);
+        let n_datalines = get_u32(buf, &mut o);
+        let _pad0 = get_u32(buf, &mut o);
+        let position_bits = get_u64(buf, &mut o);
+        let off_superblocks = get_u64(buf, &mut o);
+        let n_superblocks = get_u32(buf, &mut o);
+        let _pad1 = get_u32(buf, &mut o);
+        let mut off_sel = [0u64; 4];
+        for i in 0..4 {
+            off_sel[i] = get_u64(buf, &mut o);
+        }
+        let mut n_sel = [0u32; 4];
+        for i in 0..4 {
+            n_sel[i] = get_u32(buf, &mut o);
+        }
+        let mut n_occs_smaller = [0u64; 5];
+        for i in 0..5 {
+            n_occs_smaller[i] = get_u64(buf, &mut o);
+        }
+        Ok(Self {
+            off_data,
+            n_datalines,
+            position_bits,
+            off_superblocks,
+            n_superblocks,
+            off_sel,
+            n_sel,
+            n_occs_smaller,
+        })
+    }
+}
+
+#[inline]
+fn put_u16(out: &mut [u8], o: &mut usize, v: u16) {
+    out[*o..*o + 2].copy_from_slice(&v.to_le_bytes());
+    *o += 2;
+}
+#[inline]
+fn put_u32(out: &mut [u8], o: &mut usize, v: u32) {
+    out[*o..*o + 4].copy_from_slice(&v.to_le_bytes());
+    *o += 4;
+}
+#[inline]
+fn put_u64(out: &mut [u8], o: &mut usize, v: u64) {
+    out[*o..*o + 8].copy_from_slice(&v.to_le_bytes());
+    *o += 8;
+}
+#[inline]
+fn get_u16(buf: &[u8], o: &mut usize) -> u16 {
+    let v = u16::from_le_bytes(buf[*o..*o + 2].try_into().unwrap());
+    *o += 2;
+    v
+}
+#[inline]
+fn get_u32(buf: &[u8], o: &mut usize) -> u32 {
+    let v = u32::from_le_bytes(buf[*o..*o + 4].try_into().unwrap());
+    *o += 4;
+    v
+}
+#[inline]
+fn get_u64(buf: &[u8], o: &mut usize) -> u64 {
+    let v = u64::from_le_bytes(buf[*o..*o + 8].try_into().unwrap());
+    *o += 8;
+    v
+}
+
+/// Serialize a plain QWT256 into a `QWTB` blob.
+pub fn qwt256_to_bytes<T>(tree: &QWaveletTree<T, RSQVector<RSSupportPlain<256>>, false>) -> Result<Vec<u8>, LayoutError>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+{
+    to_bytes_generic::<T, 256>(tree)
+}
+
+/// Serialize a plain QWT512 into a `QWTB` blob.
+pub fn qwt512_to_bytes<T>(tree: &QWaveletTree<T, RSQVector<RSSupportPlain<512>>, false>) -> Result<Vec<u8>, LayoutError>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+{
+    to_bytes_generic::<T, 512>(tree)
+}
+
+fn to_bytes_generic<T, const B: usize>(
+    tree: &QWaveletTree<T, RSQVector<RSSupportPlain<B>>, false>,
+) -> Result<Vec<u8>, LayoutError>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+{
+    ensure_le()?;
+
+    let n_levels = tree.n_levels();
+    let dir_bytes = n_levels * LEVEL_DIR_SIZE;
+    let header_and_dir = HEADER_SIZE + dir_bytes;
+
+    // First pass: measure payload sizes and plan offsets.
+    let mut dirs = Vec::with_capacity(n_levels);
+    let mut cursor = align_up(header_and_dir, 64);
+
+    // Only the first n_levels entries are real; empty trees keep a default qv
+    // in the vec with n_levels == 0.
+    for level in tree.levels().iter().take(n_levels) {
+        let qv = level.qvector();
+        let rs = level.rs_support();
+        let n_datalines = qv.data_lines().len() as u32;
+        let position_bits = qv.position_bits() as u64;
+        let n_superblocks = rs.superblocks().len() as u32;
+        let n_sel: [u32; 4] = std::array::from_fn(|s| rs.select_samples(s).len() as u32);
+        let n_occs = level.n_occs_smaller();
+        let n_occs_smaller: [u64; 5] = std::array::from_fn(|i| n_occs[i] as u64);
+
+        cursor = align_up(cursor, 64);
+        let off_data = cursor as u64;
+        cursor += n_datalines as usize * size_of::<DataLine>();
+
+        cursor = align_up(cursor, 64);
+        let off_superblocks = cursor as u64;
+        cursor += n_superblocks as usize * size_of::<SuperblockPlain>();
+
+        // select samples: 4-byte aligned is fine
+        cursor = align_up(cursor, 4);
+        let mut off_sel = [0u64; 4];
+        for s in 0..4 {
+            off_sel[s] = cursor as u64;
+            cursor += n_sel[s] as usize * size_of::<u32>();
+        }
+
+        dirs.push(LevelDir {
+            off_data,
+            n_datalines,
+            position_bits,
+            off_superblocks,
+            n_superblocks,
+            off_sel,
+            n_sel,
+            n_occs_smaller,
+        });
+    }
+
+
+    let mut out = vec![0u8; cursor];
+
+    // Header
+    out[0..4].copy_from_slice(QWTB_MAGIC);
+    let mut o = 4;
+    put_u16(&mut out, &mut o, FORMAT_VERSION);
+    let flags: u8 = if B == 512 { FLAG_B512 } else { 0 };
+    out[o] = flags;
+    o += 1;
+    out[o] = size_of::<T>() as u8;
+    o += 1;
+    put_u64(&mut out, &mut o, tree.len() as u64);
+    // sigma_raw zero-extended to u64
+    let sigma_u: usize = tree.sigma_raw().as_();
+    put_u64(&mut out, &mut o, sigma_u as u64);
+    put_u16(&mut out, &mut o, n_levels as u16);
+    // reserved already zero
+    debug_assert_eq!(o, 26);
+    o = HEADER_SIZE;
+
+    // Directory
+    for dir in &dirs {
+        dir.write(&mut out[o..o + LEVEL_DIR_SIZE]);
+        o += LEVEL_DIR_SIZE;
+    }
+
+    // Payloads
+    for (level, dir) in tree.levels().iter().zip(dirs.iter()) {
+        let qv = level.qvector();
+        let rs = level.rs_support();
+
+        let off = dir.off_data as usize;
+        let nbytes = dir.n_datalines as usize * size_of::<DataLine>();
+        // SAFETY / layout: DataLine is repr(C, align(64)); we write raw bytes.
+        let src = unsafe {
+            std::slice::from_raw_parts(qv.data_lines().as_ptr() as *const u8, nbytes)
+        };
+        out[off..off + nbytes].copy_from_slice(src);
+
+        let off = dir.off_superblocks as usize;
+        let nbytes = dir.n_superblocks as usize * size_of::<SuperblockPlain>();
+        let src = unsafe {
+            std::slice::from_raw_parts(rs.superblocks().as_ptr() as *const u8, nbytes)
+        };
+        out[off..off + nbytes].copy_from_slice(src);
+
+        for s in 0..4 {
+            let off = dir.off_sel[s] as usize;
+            let n = dir.n_sel[s] as usize;
+            let samples = rs.select_samples(s);
+            debug_assert_eq!(samples.len(), n);
+            for (i, &v) in samples.iter().enumerate() {
+                out[off + i * 4..off + i * 4 + 4].copy_from_slice(&v.to_le_bytes());
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+
+/// Deserialize a `QWTB` blob into an owned QWT256.
+pub fn qwt256_from_bytes<T>(bytes: &[u8]) -> Result<QWaveletTree<T, RSQVector<RSSupportPlain<256>>, false>, LayoutError>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+    u8: AsPrimitive<T>,
+{
+    from_bytes_generic::<T, 256>(bytes)
+}
+
+/// Deserialize a `QWTB` blob into an owned QWT512.
+pub fn qwt512_from_bytes<T>(bytes: &[u8]) -> Result<QWaveletTree<T, RSQVector<RSSupportPlain<512>>, false>, LayoutError>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+    u8: AsPrimitive<T>,
+{
+    from_bytes_generic::<T, 512>(bytes)
+}
+
+fn from_bytes_generic<T, const B: usize>(
+    bytes: &[u8],
+) -> Result<QWaveletTree<T, RSQVector<RSSupportPlain<B>>, false>, LayoutError>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+    u8: AsPrimitive<T>,
+{
+    ensure_le()?;
+    if bytes.len() < HEADER_SIZE {
+        return Err(LayoutError::Truncated);
+    }
+    if &bytes[0..4] != QWTB_MAGIC {
+        return Err(LayoutError::BadMagic);
+    }
+    let mut o = 4;
+    let version = get_u16(bytes, &mut o);
+    if version != FORMAT_VERSION {
+        return Err(LayoutError::BadVersion);
+    }
+    let flags = bytes[o];
+    o += 1;
+    if flags & FLAG_PREFETCH != 0 {
+        return Err(LayoutError::PrefetchNotSupported);
+    }
+    let want_b512 = flags & FLAG_B512 != 0;
+    if (B == 512) != want_b512 {
+        return Err(LayoutError::Inconsistent {
+            detail: "B_SIZE flag does not match requested type",
+        });
+    }
+    let t_width = bytes[o];
+    o += 1;
+    if t_width as usize != size_of::<T>() {
+        return Err(LayoutError::Inconsistent {
+            detail: "t_width does not match T",
+        });
+    }
+    let n = get_u64(bytes, &mut o) as usize;
+    let sigma_u = get_u64(bytes, &mut o) as usize;
+    let sigma: T = sigma_u.as_();
+    let n_levels = get_u16(bytes, &mut o) as usize;
+    let _ = o;
+
+    let dir_end = HEADER_SIZE + n_levels * LEVEL_DIR_SIZE;
+    if bytes.len() < dir_end {
+        return Err(LayoutError::Truncated);
+    }
+
+    let mut qvs = Vec::with_capacity(n_levels);
+    for li in 0..n_levels {
+        let dir_off = HEADER_SIZE + li * LEVEL_DIR_SIZE;
+        let dir = LevelDir::read(&bytes[dir_off..dir_off + LEVEL_DIR_SIZE])?;
+
+        // Data lines — offsets must be 64-aligned in the format; the source
+        // buffer itself need not be (owned path copies into aligned heap).
+        if dir.off_data as usize % 64 != 0 {
+            return Err(LayoutError::Misaligned);
+        }
+        let data_off = dir.off_data as usize;
+        let data_bytes = dir.n_datalines as usize * size_of::<DataLine>();
+        if data_off + data_bytes > bytes.len() {
+            return Err(LayoutError::Truncated);
+        }
+        let lines = copy_pod_slice::<DataLine>(&bytes[data_off..], dir.n_datalines as usize)?;
+        let qv = QVector::from_raw_parts(lines, dir.position_bits as usize);
+
+        // Superblocks
+        if dir.off_superblocks as usize % 64 != 0 {
+            return Err(LayoutError::Misaligned);
+        }
+        let sb_off = dir.off_superblocks as usize;
+        let sb_bytes = dir.n_superblocks as usize * size_of::<SuperblockPlain>();
+        if sb_off + sb_bytes > bytes.len() {
+            return Err(LayoutError::Truncated);
+        }
+        let superblocks =
+            copy_pod_slice::<SuperblockPlain>(&bytes[sb_off..], dir.n_superblocks as usize)?;
+
+
+        // Select samples
+        let mut select_samples: [Box<[u32]>; 4] = Default::default();
+        for s in 0..4 {
+            let n_sel = dir.n_sel[s] as usize;
+            let off = dir.off_sel[s] as usize;
+            let end = off + n_sel * 4;
+            if end > bytes.len() {
+                return Err(LayoutError::Truncated);
+            }
+            let mut v = Vec::with_capacity(n_sel);
+            for i in 0..n_sel {
+                let b = off + i * 4;
+                v.push(u32::from_le_bytes(bytes[b..b + 4].try_into().unwrap()));
+            }
+            select_samples[s] = v.into_boxed_slice();
+        }
+
+        let rs = RSSupportPlain::<B>::from_parts(superblocks, select_samples);
+        let n_occs: [usize; 5] = std::array::from_fn(|i| dir.n_occs_smaller[i] as usize);
+        qvs.push(RSQVector::from_parts(qv, rs, n_occs));
+    }
+
+    // Empty-tree convention in qwt::new uses one default level; from_parts
+    // accepts n_levels==0 with empty qvs, or the serde-empty shape.
+    if n == 0 && qvs.is_empty() {
+        qvs.push(RSQVector::default());
+    }
+
+    QWaveletTree::from_parts(n, n_levels, sigma, qvs)
+}
+
+
+// Silence "RSforWT unused" when only used via bound on QWaveletTree methods.
+const _: fn() = || {
+    fn assert_rsforwt<T: RSforWT>() {}
+    let _ = assert_rsforwt::<RSQVector<RSSupportPlain<256>>>;
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AccessUnsigned, QWT256, RankUnsigned, SelectUnsigned};
+
+    #[test]
+    fn qwtb_roundtrip_get_rank_select() {
+        let data: Vec<u32> = (0..1000).map(|x| (x * 3) % 128).collect();
+        let original = QWT256::from(data.clone());
+        let bytes = qwt256_to_bytes(&original).unwrap();
+        assert_eq!(&bytes[0..4], QWTB_MAGIC);
+        let rebuilt: QWT256<u32> = qwt256_from_bytes(&bytes).unwrap();
+
+        assert_eq!(original.len(), rebuilt.len());
+        assert_eq!(original.n_levels(), rebuilt.n_levels());
+        assert_eq!(original.sigma_raw(), rebuilt.sigma_raw());
+
+        for i in 0..data.len() {
+            assert_eq!(original.get(i), rebuilt.get(i), "get@{i}");
+        }
+        for &sym in &[0u32, 1, 5, 64, 127] {
+            for i in (0..=data.len()).step_by(31) {
+                assert_eq!(original.rank(sym, i), rebuilt.rank(sym, i), "rank({sym},{i})");
+            }
+            if let Some(cnt) = original.rank(sym, data.len()) {
+                for k in 0..cnt.min(3) {
+                    assert_eq!(
+                        original.select(sym, k),
+                        rebuilt.select(sym, k),
+                        "select({sym},{k})"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn qwtb_empty_tree() {
+        // Empty trees use n_levels=0 with one default qv sentinel.
+        let mut empty: Vec<u32> = vec![];
+        let original = QWT256::new(&mut empty);
+        let bytes = qwt256_to_bytes(&original).unwrap();
+        let rebuilt: QWT256<u32> = qwt256_from_bytes(&bytes).unwrap();
+        assert_eq!(rebuilt.len(), 0);
+        assert!(rebuilt.is_empty());
+        assert_eq!(rebuilt.n_levels(), 0);
+    }
+
+
+    #[test]
+    fn qwtb_bad_magic() {
+        let mut bytes = qwt256_to_bytes(&QWT256::from(vec![1u32, 2, 3])).unwrap();
+        bytes[0] = b'X';
+        let err = qwt256_from_bytes::<u32>(&bytes).unwrap_err();
+        assert_eq!(err, LayoutError::BadMagic);
+    }
+
+    #[test]
+    fn qwtb_truncated() {
+        let err = qwt256_from_bytes::<u32>(&[0u8; 8]).unwrap_err();
+        assert!(matches!(err, LayoutError::BadMagic | LayoutError::Truncated));
+    }
+}

--- a/src/bytes/qwtb.rs
+++ b/src/bytes/qwtb.rs
@@ -356,8 +356,21 @@ where
     let sigma: T = sigma_u.as_();
     let n_levels = get_u16(bytes, &mut o) as usize;
     let _ = o;
+    let max_type_levels = (size_of::<T>() * u8::BITS as usize).div_ceil(2);
+    if sigma.as_() != sigma_u
+        || n_levels > crate::MAX_QUAD_LEVELS
+        || n_levels > max_type_levels
+        || (n > 0 && n_levels == 0)
+    {
+        return Err(LayoutError::Inconsistent {
+            detail: "plain QWT header values are invalid for the requested type",
+        });
+    }
 
-    let dir_end = HEADER_SIZE + n_levels * LEVEL_DIR_SIZE;
+    let dir_end = n_levels
+        .checked_mul(LEVEL_DIR_SIZE)
+        .and_then(|size| HEADER_SIZE.checked_add(size))
+        .ok_or(LayoutError::Truncated)?;
     if bytes.len() < dir_end {
         return Err(LayoutError::Truncated);
     }
@@ -375,8 +388,18 @@ where
         let data_off = dir.off_data as usize;
         let n_datalines = dir.n_datalines as usize;
         let _ = checked_region(data_off, n_datalines, size_of::<DataLine>(), bytes.len())?;
-        let lines = copy_pod_slice::<DataLine>(&bytes[data_off..], n_datalines)?;
-        let qv = QVector::from_raw_parts(lines, dir.position_bits as usize);
+        // SAFETY: DataLine is repr(C), contains only integers, and accepts every bit pattern.
+        let lines = unsafe { copy_pod_slice::<DataLine>(&bytes[data_off..], n_datalines)? };
+        let position_bits =
+            usize::try_from(dir.position_bits).map_err(|_| LayoutError::Inconsistent {
+                detail: "position_bits exceeds usize",
+            })?;
+        if !position_bits.is_multiple_of(2) || position_bits > n_datalines.saturating_mul(512) {
+            return Err(LayoutError::Inconsistent {
+                detail: "position_bits is invalid for the data payload",
+            });
+        }
+        let qv = QVector::from_raw_parts(lines, position_bits);
 
         // Superblocks
         if !(dir.off_superblocks as usize).is_multiple_of(64) {
@@ -390,25 +413,18 @@ where
             size_of::<SuperblockPlain>(),
             bytes.len(),
         )?;
-        let superblocks = copy_pod_slice::<SuperblockPlain>(&bytes[sb_off..], n_superblocks)?;
 
         // Select samples
-        let mut select_samples: [Box<[u32]>; 4] = Default::default();
-        for (s, sample_slot) in select_samples.iter_mut().enumerate() {
+        for s in 0..4 {
             let n_sel = dir.n_sel[s] as usize;
             let off = dir.off_sel[s] as usize;
             let _ = checked_region(off, n_sel, size_of::<u32>(), bytes.len())?;
-            let mut v = Vec::with_capacity(n_sel);
-            for i in 0..n_sel {
-                let b = off + i * 4;
-                v.push(u32::from_le_bytes(bytes[b..b + 4].try_into().unwrap()));
-            }
-            *sample_slot = v.into_boxed_slice();
         }
 
-        let rs = RSSupportPlain::<B>::from_parts(superblocks, select_samples);
-        let n_occs: [usize; 5] = std::array::from_fn(|i| dir.n_occs_smaller[i] as usize);
-        qvs.push(RSQVector::from_parts(qv, rs, n_occs));
+        // Rebuild all rank/select metadata from the validated symbol payload.
+        // Persisted counters are an untrusted cache and must never reach the
+        // owned structure's unchecked query paths.
+        qvs.push(RSQVector::<RSSupportPlain<B>>::from(qv));
     }
 
     // Empty-tree convention in qwt::new uses one default level; from_parts
@@ -484,6 +500,22 @@ mod tests {
         bytes[0] = b'X';
         let err = qwt256_from_bytes::<u32>(&bytes).unwrap_err();
         assert_eq!(err, LayoutError::BadMagic);
+    }
+
+    #[test]
+    fn qwtb_rejects_sigma_that_disagrees_with_payload() {
+        let mut bytes = qwt256_to_bytes(&QWT256::from(vec![1u32, 2, 3])).unwrap();
+        bytes[16..24].copy_from_slice(&2u64.to_le_bytes());
+        let error = qwt256_from_bytes::<u32>(&bytes).unwrap_err();
+        assert!(matches!(error, LayoutError::Inconsistent { .. }));
+    }
+
+    #[test]
+    fn qwtb_owned_decoder_rejects_invalid_position_without_panicking() {
+        let mut bytes = qwt256_to_bytes(&QWT256::from(vec![1u32, 2, 3])).unwrap();
+        bytes[HEADER_SIZE + 16..HEADER_SIZE + 24].copy_from_slice(&1u64.to_le_bytes());
+        let error = qwt256_from_bytes::<u32>(&bytes).unwrap_err();
+        assert!(matches!(error, LayoutError::Inconsistent { .. }));
     }
 
     #[test]

--- a/src/bytes/util.rs
+++ b/src/bytes/util.rs
@@ -14,10 +14,37 @@ pub fn ensure_le() -> Result<(), LayoutError> {
 }
 
 /// Round `n` up to a multiple of `align` (power of two).
+///
+/// Returns `n` unchanged if the addition would overflow (callers treating the
+/// result as a byte offset will then fail a subsequent bounds check).
 #[inline]
 pub fn align_up(n: usize, align: usize) -> usize {
     debug_assert!(align.is_power_of_two());
-    (n + align - 1) & !(align - 1)
+    match n.checked_add(align - 1) {
+        Some(sum) => sum & !(align - 1),
+        None => n,
+    }
+}
+
+/// Compute `count * elem_size` and verify `off + that <= buf_len`.
+///
+/// Used by decode paths where `off`/`count` come from untrusted headers.
+/// Returns the byte length of the region on success.
+#[inline]
+pub fn checked_region(
+    off: usize,
+    count: usize,
+    elem_size: usize,
+    buf_len: usize,
+) -> Result<usize, LayoutError> {
+    let nbytes = count
+        .checked_mul(elem_size)
+        .ok_or(LayoutError::Truncated)?;
+    let end = off.checked_add(nbytes).ok_or(LayoutError::Truncated)?;
+    if end > buf_len {
+        return Err(LayoutError::Truncated);
+    }
+    Ok(nbytes)
 }
 
 /// Reinterpret an aligned byte slice as a slice of `T`.
@@ -52,7 +79,6 @@ pub fn cast_slice<T>(bytes: &[u8]) -> Result<&[T], LayoutError> {
 #[inline]
 #[allow(dead_code)] // reserved for in-place writers
 pub fn cast_slice_mut<T>(bytes: &mut [u8]) -> Result<&mut [T], LayoutError> {
-
     if bytes.is_empty() {
         return Ok(&mut []);
     }
@@ -80,7 +106,9 @@ pub fn cast_slice_mut<T>(bytes: &mut [u8]) -> Result<&mut [T], LayoutError> {
 /// - [`LayoutError::Truncated`] if `bytes.len() < n * size_of::<T>()`
 #[inline]
 pub fn copy_pod_slice<T: Copy + Default>(bytes: &[u8], n: usize) -> Result<Box<[T]>, LayoutError> {
-    let need = n.checked_mul(size_of::<T>()).ok_or(LayoutError::Truncated)?;
+    let need = n
+        .checked_mul(size_of::<T>())
+        .ok_or(LayoutError::Truncated)?;
     if bytes.len() < need {
         return Err(LayoutError::Truncated);
     }
@@ -103,8 +131,6 @@ pub fn copy_pod_slice<T: Copy + Default>(bytes: &[u8], n: usize) -> Result<Box<[
 #[inline]
 #[allow(dead_code)] // reserved for bulk POD writers
 pub fn write_slice<T>(out: &mut Vec<u8>, data: &[T]) {
-
-
     if data.is_empty() {
         return;
     }
@@ -149,7 +175,7 @@ mod tests {
     #[test]
     fn cast_rejects_short() {
         let buf = [0u8; 32]; // half a DataLine
-        // May also fail alignment; either error is fine.
+                             // May also fail alignment; either error is fine.
         assert!(cast_slice::<DataLine>(&buf).is_err());
     }
 }

--- a/src/bytes/util.rs
+++ b/src/bytes/util.rs
@@ -67,12 +67,40 @@ pub fn cast_slice_mut<T>(bytes: &mut [u8]) -> Result<&mut [T], LayoutError> {
     Ok(unsafe { std::slice::from_raw_parts_mut(bytes.as_mut_ptr() as *mut T, len) })
 }
 
+/// Copy a POD array out of a (possibly unaligned) byte slice into a freshly
+/// allocated, naturally aligned `Box<[T]>`.
+///
+/// Used by the owned `from_bytes` path, which must not require the source
+/// buffer to be 64-byte aligned (heap `Vec<u8>` typically is not). Zero-copy
+/// views should keep using [`cast_slice`] and reject misaligned inputs.
+///
+/// # Errors
+/// - [`LayoutError::Truncated`] if `bytes.len() < n * size_of::<T>()`
+#[inline]
+pub fn copy_pod_slice<T: Copy + Default>(bytes: &[u8], n: usize) -> Result<Box<[T]>, LayoutError> {
+    let need = n.checked_mul(size_of::<T>()).ok_or(LayoutError::Truncated)?;
+    if bytes.len() < need {
+        return Err(LayoutError::Truncated);
+    }
+    if n == 0 {
+        return Ok(Box::from([]));
+    }
+    let mut out = vec![T::default(); n];
+    // SAFETY: T is POD by caller contract; we copy exactly `need` bytes into
+    // a freshly allocated, naturally aligned buffer of `n` T values.
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), out.as_mut_ptr() as *mut u8, need);
+    }
+    Ok(out.into_boxed_slice())
+}
+
 /// Append the raw bytes of a POD slice to `out`.
 ///
 /// Uses `std::slice::from_raw_parts` on the typed slice so the in-memory
 /// `#[repr(C)]` layout is preserved byte-for-byte.
 #[inline]
 pub fn write_slice<T>(out: &mut Vec<u8>, data: &[T]) {
+
     if data.is_empty() {
         return;
     }

--- a/src/bytes/util.rs
+++ b/src/bytes/util.rs
@@ -37,9 +37,7 @@ pub fn checked_region(
     elem_size: usize,
     buf_len: usize,
 ) -> Result<usize, LayoutError> {
-    let nbytes = count
-        .checked_mul(elem_size)
-        .ok_or(LayoutError::Truncated)?;
+    let nbytes = count.checked_mul(elem_size).ok_or(LayoutError::Truncated)?;
     let end = off.checked_add(nbytes).ok_or(LayoutError::Truncated)?;
     if end > buf_len {
         return Err(LayoutError::Truncated);
@@ -64,7 +62,7 @@ pub fn cast_slice<T>(bytes: &[u8]) -> Result<&[T], LayoutError> {
     }
     let align = align_of::<T>();
     let addr = bytes.as_ptr() as usize;
-    if addr % align != 0 {
+    if !addr.is_multiple_of(align) {
         return Err(LayoutError::Misaligned);
     }
     if !bytes.len().is_multiple_of(size_of::<T>()) {
@@ -84,9 +82,10 @@ pub fn cast_slice_mut<T>(bytes: &mut [u8]) -> Result<&mut [T], LayoutError> {
     }
     let align = align_of::<T>();
     let addr = bytes.as_ptr() as usize;
-    if addr % align != 0 {
+    if !addr.is_multiple_of(align) {
         return Err(LayoutError::Misaligned);
     }
+
     if !bytes.len().is_multiple_of(size_of::<T>()) {
         return Err(LayoutError::Truncated);
     }
@@ -134,7 +133,7 @@ pub fn write_slice<T>(out: &mut Vec<u8>, data: &[T]) {
     if data.is_empty() {
         return;
     }
-    let nbytes = data.len() * size_of::<T>();
+    let nbytes = std::mem::size_of_val(data);
     // SAFETY: T is POD; we only read its bytes.
     let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, nbytes) };
     out.extend_from_slice(bytes);

--- a/src/bytes/util.rs
+++ b/src/bytes/util.rs
@@ -50,7 +50,9 @@ pub fn cast_slice<T>(bytes: &[u8]) -> Result<&[T], LayoutError> {
 
 /// Mutable variant of [`cast_slice`].
 #[inline]
+#[allow(dead_code)] // reserved for in-place writers
 pub fn cast_slice_mut<T>(bytes: &mut [u8]) -> Result<&mut [T], LayoutError> {
+
     if bytes.is_empty() {
         return Ok(&mut []);
     }
@@ -99,7 +101,9 @@ pub fn copy_pod_slice<T: Copy + Default>(bytes: &[u8], n: usize) -> Result<Box<[
 /// Uses `std::slice::from_raw_parts` on the typed slice so the in-memory
 /// `#[repr(C)]` layout is preserved byte-for-byte.
 #[inline]
+#[allow(dead_code)] // reserved for bulk POD writers
 pub fn write_slice<T>(out: &mut Vec<u8>, data: &[T]) {
+
 
     if data.is_empty() {
         return;

--- a/src/bytes/util.rs
+++ b/src/bytes/util.rs
@@ -1,0 +1,123 @@
+//! Low-level helpers for the byte I/O layer.
+
+use super::LayoutError;
+use std::mem::{align_of, size_of};
+
+/// Reject big-endian hosts. The v1 format is little-endian only.
+#[inline]
+pub fn ensure_le() -> Result<(), LayoutError> {
+    if cfg!(target_endian = "little") {
+        Ok(())
+    } else {
+        Err(LayoutError::NotLittleEndian)
+    }
+}
+
+/// Round `n` up to a multiple of `align` (power of two).
+#[inline]
+pub fn align_up(n: usize, align: usize) -> usize {
+    debug_assert!(align.is_power_of_two());
+    (n + align - 1) & !(align - 1)
+}
+
+/// Reinterpret an aligned byte slice as a slice of `T`.
+///
+/// # Errors
+/// - [`LayoutError::Misaligned`] if `bytes.as_ptr()` is not aligned for `T`
+/// - [`LayoutError::Truncated`] if `bytes.len()` is not a multiple of `size_of::<T>()`
+///
+/// # Safety considerations
+/// `T` must be a plain-old-data type with no padding that would make an
+/// arbitrary bit pattern invalid (e.g. `DataLine`, `SuperblockPlain`, `u32`).
+/// Callers must uphold that invariant; this helper only checks alignment and length.
+#[inline]
+pub fn cast_slice<T>(bytes: &[u8]) -> Result<&[T], LayoutError> {
+    if bytes.is_empty() {
+        return Ok(&[]);
+    }
+    let align = align_of::<T>();
+    let addr = bytes.as_ptr() as usize;
+    if addr % align != 0 {
+        return Err(LayoutError::Misaligned);
+    }
+    if !bytes.len().is_multiple_of(size_of::<T>()) {
+        return Err(LayoutError::Truncated);
+    }
+    let len = bytes.len() / size_of::<T>();
+    // SAFETY: alignment and length checked; T is POD by caller contract.
+    Ok(unsafe { std::slice::from_raw_parts(bytes.as_ptr() as *const T, len) })
+}
+
+/// Mutable variant of [`cast_slice`].
+#[inline]
+pub fn cast_slice_mut<T>(bytes: &mut [u8]) -> Result<&mut [T], LayoutError> {
+    if bytes.is_empty() {
+        return Ok(&mut []);
+    }
+    let align = align_of::<T>();
+    let addr = bytes.as_ptr() as usize;
+    if addr % align != 0 {
+        return Err(LayoutError::Misaligned);
+    }
+    if !bytes.len().is_multiple_of(size_of::<T>()) {
+        return Err(LayoutError::Truncated);
+    }
+    let len = bytes.len() / size_of::<T>();
+    // SAFETY: alignment and length checked; T is POD by caller contract.
+    Ok(unsafe { std::slice::from_raw_parts_mut(bytes.as_mut_ptr() as *mut T, len) })
+}
+
+/// Append the raw bytes of a POD slice to `out`.
+///
+/// Uses `std::slice::from_raw_parts` on the typed slice so the in-memory
+/// `#[repr(C)]` layout is preserved byte-for-byte.
+#[inline]
+pub fn write_slice<T>(out: &mut Vec<u8>, data: &[T]) {
+    if data.is_empty() {
+        return;
+    }
+    let nbytes = data.len() * size_of::<T>();
+    // SAFETY: T is POD; we only read its bytes.
+    let bytes = unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, nbytes) };
+    out.extend_from_slice(bytes);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::qvector::DataLine;
+
+    #[test]
+    fn align_up_basic() {
+        assert_eq!(align_up(0, 64), 0);
+        assert_eq!(align_up(1, 64), 64);
+        assert_eq!(align_up(64, 64), 64);
+        assert_eq!(align_up(65, 64), 128);
+    }
+
+    #[test]
+    fn cast_empty() {
+        let empty: &[DataLine] = cast_slice::<DataLine>(&[]).unwrap();
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn cast_aligned_dataline() {
+        // Allocate a 64-aligned buffer holding one DataLine of zeros.
+        let mut buf = vec![0u8; 128];
+        let start = align_up(buf.as_ptr() as usize, 64) - buf.as_ptr() as usize;
+        let slice = &buf[start..start + 64];
+        let lines: &[DataLine] = cast_slice(slice).unwrap();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].words, [0; 4]);
+        // silence unused mut
+        let _ = &mut buf;
+    }
+
+    #[test]
+    fn cast_rejects_short() {
+        let buf = [0u8; 32]; // half a DataLine
+        // May also fail alignment; either error is fine.
+        assert!(cast_slice::<DataLine>(&buf).is_err());
+    }
+}

--- a/src/bytes/util.rs
+++ b/src/bytes/util.rs
@@ -51,12 +51,14 @@ pub fn checked_region(
 /// - [`LayoutError::Misaligned`] if `bytes.as_ptr()` is not aligned for `T`
 /// - [`LayoutError::Truncated`] if `bytes.len()` is not a multiple of `size_of::<T>()`
 ///
-/// # Safety considerations
-/// `T` must be a plain-old-data type with no padding that would make an
-/// arbitrary bit pattern invalid (e.g. `DataLine`, `SuperblockPlain`, `u32`).
-/// Callers must uphold that invariant; this helper only checks alignment and length.
+/// # Safety
+///
+/// `T` must be a plain-old-data type for which every bit pattern is valid and
+/// whose initialized representation may be read from the complete byte slice
+/// (e.g. `DataLine`, `SuperblockPlain`, or `u32`). This helper checks only
+/// alignment and length.
 #[inline]
-pub fn cast_slice<T>(bytes: &[u8]) -> Result<&[T], LayoutError> {
+pub unsafe fn cast_slice<T>(bytes: &[u8]) -> Result<&[T], LayoutError> {
     if bytes.is_empty() {
         return Ok(&[]);
     }
@@ -74,9 +76,14 @@ pub fn cast_slice<T>(bytes: &[u8]) -> Result<&[T], LayoutError> {
 }
 
 /// Mutable variant of [`cast_slice`].
+///
+/// # Safety
+///
+/// The requirements of [`cast_slice`] apply. In addition, every byte of each
+/// `T` value must be initialized before the returned slice is read.
 #[inline]
 #[allow(dead_code)] // reserved for in-place writers
-pub fn cast_slice_mut<T>(bytes: &mut [u8]) -> Result<&mut [T], LayoutError> {
+pub unsafe fn cast_slice_mut<T>(bytes: &mut [u8]) -> Result<&mut [T], LayoutError> {
     if bytes.is_empty() {
         return Ok(&mut []);
     }
@@ -103,8 +110,15 @@ pub fn cast_slice_mut<T>(bytes: &mut [u8]) -> Result<&mut [T], LayoutError> {
 ///
 /// # Errors
 /// - [`LayoutError::Truncated`] if `bytes.len() < n * size_of::<T>()`
+///
+/// # Safety
+///
+/// `T` must be a plain-old-data type for which every bit pattern is valid.
 #[inline]
-pub fn copy_pod_slice<T: Copy + Default>(bytes: &[u8], n: usize) -> Result<Box<[T]>, LayoutError> {
+pub unsafe fn copy_pod_slice<T: Copy + Default>(
+    bytes: &[u8],
+    n: usize,
+) -> Result<Box<[T]>, LayoutError> {
     let need = n
         .checked_mul(size_of::<T>())
         .ok_or(LayoutError::Truncated)?;
@@ -127,9 +141,14 @@ pub fn copy_pod_slice<T: Copy + Default>(bytes: &[u8], n: usize) -> Result<Box<[
 ///
 /// Uses `std::slice::from_raw_parts` on the typed slice so the in-memory
 /// `#[repr(C)]` layout is preserved byte-for-byte.
+///
+/// # Safety
+///
+/// `T` must have a fully initialized plain-old-data representation with no
+/// uninitialized padding bytes.
 #[inline]
 #[allow(dead_code)] // reserved for bulk POD writers
-pub fn write_slice<T>(out: &mut Vec<u8>, data: &[T]) {
+pub unsafe fn write_slice<T>(out: &mut Vec<u8>, data: &[T]) {
     if data.is_empty() {
         return;
     }
@@ -154,7 +173,8 @@ mod tests {
 
     #[test]
     fn cast_empty() {
-        let empty: &[DataLine] = cast_slice::<DataLine>(&[]).unwrap();
+        // SAFETY: DataLine is POD and every bit pattern is valid.
+        let empty: &[DataLine] = unsafe { cast_slice::<DataLine>(&[]) }.unwrap();
         assert!(empty.is_empty());
     }
 
@@ -164,7 +184,8 @@ mod tests {
         let mut buf = vec![0u8; 128];
         let start = align_up(buf.as_ptr() as usize, 64) - buf.as_ptr() as usize;
         let slice = &buf[start..start + 64];
-        let lines: &[DataLine] = cast_slice(slice).unwrap();
+        // SAFETY: DataLine is POD and the test bytes are initialized.
+        let lines: &[DataLine] = unsafe { cast_slice(slice) }.unwrap();
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0].words, [0; 4]);
         // silence unused mut
@@ -175,6 +196,7 @@ mod tests {
     fn cast_rejects_short() {
         let buf = [0u8; 32]; // half a DataLine
                              // May also fail alignment; either error is fine.
-        assert!(cast_slice::<DataLine>(&buf).is_err());
+                             // SAFETY: DataLine is POD; this call is expected to reject alignment.
+        assert!(unsafe { cast_slice::<DataLine>(&buf) }.is_err());
     }
 }

--- a/src/bytes/view.rs
+++ b/src/bytes/view.rs
@@ -662,7 +662,7 @@ mod tests {
         // (almost always), from_bytes should fail with Misaligned when casting.
         let slice = &padded[1..];
         let addr = slice.as_ptr() as usize;
-        if addr % 64 != 0 && original.n_levels() > 0 {
+        if !addr.is_multiple_of(64) && original.n_levels() > 0 {
             let err = QwtView::<u32, 256>::from_bytes(slice).unwrap_err();
             assert_eq!(err, LayoutError::Misaligned);
         }

--- a/src/bytes/view.rs
+++ b/src/bytes/view.rs
@@ -2,13 +2,12 @@
 //!
 //! The caller owns the underlying bytes (mmap, `AlignedBuf`, …). These views
 //! cast POD slices in place and never allocate for level payloads. Huffman
-//! code tables are small and are decoded into owned side allocations
-//! (design §3.3 / §4.2).
+//! code tables are small and are decoded into owned side allocations.
 
 use super::level::{HqwtLevelDir, LevelDir, RSQVectorView};
 use super::{
-    align_up, ensure_le, LayoutError, FLAG_B512, FLAG_PREFETCH, FORMAT_VERSION, HEADER_SIZE,
-    HQWB_MAGIC, HQWT_LEVEL_DIR_SIZE, LEVEL_DIR_SIZE, QWTB_MAGIC,
+    align_up, checked_region, ensure_le, LayoutError, FLAG_B512, FLAG_PREFETCH, FORMAT_VERSION,
+    HEADER_SIZE, HQWB_MAGIC, HQWT_LEVEL_DIR_SIZE, LEVEL_DIR_SIZE, QWTB_MAGIC,
 };
 use crate::quadwt::huffqwt::PrefixCode;
 use crate::quadwt::WTIndexable;
@@ -319,10 +318,7 @@ where
 
         // Code tables (owned) — after directory, 8-aligned.
         let mut p = align_up(dir_end, 8);
-        let encode_bytes = encode_len * 8;
-        if p + encode_bytes > bytes.len() {
-            return Err(LayoutError::Truncated);
-        }
+        let encode_bytes = checked_region(p, encode_len, 8, bytes.len())?;
         let mut codes_encode = Vec::with_capacity(encode_len);
         for i in 0..encode_len {
             let base = p + i * 8;
@@ -334,15 +330,10 @@ where
 
         let mut codes_decode: Vec<Vec<(u32, T)>> = Vec::with_capacity(decode_n_buckets);
         for _ in 0..decode_n_buckets {
-            if p + 4 > bytes.len() {
-                return Err(LayoutError::Truncated);
-            }
+            let _ = checked_region(p, 1, 4, bytes.len())?;
             let n_entries = u32::from_le_bytes(bytes[p..p + 4].try_into().unwrap()) as usize;
             p += 4;
-            let need = n_entries * 12;
-            if p + need > bytes.len() {
-                return Err(LayoutError::Truncated);
-            }
+            let _ = checked_region(p, n_entries, 12, bytes.len())?;
             let mut bucket = Vec::with_capacity(n_entries);
             for _ in 0..n_entries {
                 let content = u32::from_le_bytes(bytes[p..p + 4].try_into().unwrap());
@@ -606,7 +597,6 @@ impl std::ops::Deref for AlignedBytes {
     }
 }
 
-
 // ── tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -730,4 +720,3 @@ mod tests {
         assert_eq!(err, LayoutError::BadMagic);
     }
 }
-

--- a/src/bytes/view.rs
+++ b/src/bytes/view.rs
@@ -1,0 +1,733 @@
+//! Zero-copy borrowed views over `QWTB` / `HQWB` containers.
+//!
+//! The caller owns the underlying bytes (mmap, `AlignedBuf`, …). These views
+//! cast POD slices in place and never allocate for level payloads. Huffman
+//! code tables are small and are decoded into owned side allocations
+//! (design §3.3 / §4.2).
+
+use super::level::{HqwtLevelDir, LevelDir, RSQVectorView};
+use super::{
+    align_up, ensure_le, LayoutError, FLAG_B512, FLAG_PREFETCH, FORMAT_VERSION, HEADER_SIZE,
+    HQWB_MAGIC, HQWT_LEVEL_DIR_SIZE, LEVEL_DIR_SIZE, QWTB_MAGIC,
+};
+use crate::quadwt::huffqwt::PrefixCode;
+use crate::quadwt::WTIndexable;
+use crate::{AccessUnsigned, RankUnsigned, SelectUnsigned};
+use num_traits::AsPrimitive;
+use std::marker::PhantomData;
+use std::mem::size_of;
+
+// ── Plain QWT view ──────────────────────────────────────────────────────────
+
+/// Borrowing plain quad wavelet tree over a `QWTB` blob.
+///
+/// Implements [`AccessUnsigned`], [`RankUnsigned`], and [`SelectUnsigned`].
+/// The underlying `&[u8]` must outlive the view and its absolute base address
+/// must be 64-byte aligned so POD casts of `DataLine` / `SuperblockPlain`
+/// succeed (format offsets are already 64-aligned).
+#[derive(Clone, Debug)]
+pub struct QwtView<'a, T, const B_SIZE: usize = 256> {
+    n: usize,
+    n_levels: usize,
+    sigma: T,
+    levels: Vec<RSQVectorView<'a, B_SIZE>>,
+    _marker: PhantomData<&'a [u8]>,
+}
+
+impl<'a, T, const B_SIZE: usize> QwtView<'a, T, B_SIZE>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+    u8: AsPrimitive<T>,
+{
+    /// Open a zero-copy view over a `QWTB` blob.
+    ///
+    /// # Errors
+    /// Layout / magic / version / alignment failures — see [`LayoutError`].
+    pub fn from_bytes(bytes: &'a [u8]) -> Result<Self, LayoutError> {
+        ensure_le()?;
+        if bytes.len() < HEADER_SIZE {
+            return Err(LayoutError::Truncated);
+        }
+        if &bytes[0..4] != QWTB_MAGIC {
+            return Err(LayoutError::BadMagic);
+        }
+        let mut o = 4;
+        let version = get_u16(bytes, &mut o);
+        if version != FORMAT_VERSION {
+            return Err(LayoutError::BadVersion);
+        }
+        let flags = bytes[o];
+        o += 1;
+        if flags & FLAG_PREFETCH != 0 {
+            return Err(LayoutError::PrefetchNotSupported);
+        }
+        let want_b512 = flags & FLAG_B512 != 0;
+        if (B_SIZE == 512) != want_b512 {
+            return Err(LayoutError::Inconsistent {
+                detail: "B_SIZE flag does not match requested type",
+            });
+        }
+        let t_width = bytes[o];
+        o += 1;
+        if t_width as usize != size_of::<T>() {
+            return Err(LayoutError::Inconsistent {
+                detail: "t_width does not match T",
+            });
+        }
+        let n = get_u64(bytes, &mut o) as usize;
+        let sigma_u = get_u64(bytes, &mut o) as usize;
+        let sigma: T = sigma_u.as_();
+        let n_levels = get_u16(bytes, &mut o) as usize;
+        let _ = o;
+
+        let dir_end = HEADER_SIZE + n_levels * LEVEL_DIR_SIZE;
+        if bytes.len() < dir_end {
+            return Err(LayoutError::Truncated);
+        }
+
+        let mut levels = Vec::with_capacity(n_levels);
+        for li in 0..n_levels {
+            let dir_off = HEADER_SIZE + li * LEVEL_DIR_SIZE;
+            let dir = LevelDir::read(&bytes[dir_off..dir_off + LEVEL_DIR_SIZE])?;
+            levels.push(RSQVectorView::from_dir(bytes, &dir)?);
+        }
+
+        Ok(Self {
+            n,
+            n_levels,
+            sigma,
+            levels,
+            _marker: PhantomData,
+        })
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.n
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.n == 0
+    }
+
+    #[inline]
+    pub fn n_levels(&self) -> usize {
+        self.n_levels
+    }
+
+    #[inline]
+    pub fn sigma_raw(&self) -> T {
+        self.sigma
+    }
+
+    #[inline]
+    pub fn levels(&self) -> &[RSQVectorView<'a, B_SIZE>] {
+        &self.levels
+    }
+}
+
+impl<'a, T, const B_SIZE: usize> AccessUnsigned for QwtView<'a, T, B_SIZE>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+{
+    type Item = T;
+
+    #[inline(always)]
+    fn get(&self, i: usize) -> Option<Self::Item> {
+        if i >= self.n || self.n_levels == 0 {
+            return None;
+        }
+        Some(unsafe { self.get_unchecked(i) })
+    }
+
+    #[inline(always)]
+    unsafe fn get_unchecked(&self, i: usize) -> Self::Item {
+        debug_assert!(self.n_levels > 0);
+        let mut result = T::zero();
+        let mut cur_i = i;
+        for level in 0..self.n_levels - 1 {
+            let lv = &self.levels[level];
+            let symbol = lv.get_unchecked(cur_i);
+            result = (result << 2) | (symbol as usize).as_();
+            let offset = lv.occs_smaller_unchecked(symbol);
+            cur_i = lv.rank_unchecked(symbol, cur_i) + offset;
+        }
+        let lv = &self.levels[self.n_levels - 1];
+        let symbol = lv.get_unchecked(cur_i);
+        (result << 2) | (symbol as usize).as_()
+    }
+}
+
+impl<'a, T, const B_SIZE: usize> RankUnsigned for QwtView<'a, T, B_SIZE>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+{
+    #[inline(always)]
+    fn rank(&self, symbol: Self::Item, i: usize) -> Option<usize> {
+        if self.n_levels == 0 {
+            return if i <= self.n { Some(0) } else { None };
+        }
+        if i > self.n || symbol > self.sigma {
+            return None;
+        }
+        Some(unsafe { self.rank_unchecked(symbol, i) })
+    }
+
+    #[inline(always)]
+    unsafe fn rank_unchecked(&self, symbol: Self::Item, i: usize) -> usize {
+        debug_assert!(self.n_levels > 0);
+        let mut shift: i64 = (2 * (self.n_levels - 1)) as i64;
+        let mut cur_i = i;
+        let mut cur_p = 0usize;
+
+        for level in 0..self.n_levels - 1 {
+            let two_bits: u8 = ((symbol >> shift as usize).as_() & 3) as u8;
+            let lv = &self.levels[level];
+            let offset = lv.occs_smaller_unchecked(two_bits);
+            cur_p = lv.rank_unchecked(two_bits, cur_p) + offset;
+            cur_i = lv.rank_unchecked(two_bits, cur_i) + offset;
+            shift -= 2;
+        }
+
+        let two_bits: u8 = ((symbol >> shift as usize).as_() & 3) as u8;
+        let lv = &self.levels[self.n_levels - 1];
+        cur_i = lv.rank_unchecked(two_bits, cur_i);
+        cur_p = lv.rank_unchecked(two_bits, cur_p);
+        cur_i - cur_p
+    }
+}
+
+impl<'a, T, const B_SIZE: usize> SelectUnsigned for QwtView<'a, T, B_SIZE>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+{
+    #[inline(always)]
+    fn select(&self, symbol: Self::Item, i: usize) -> Option<usize> {
+        if self.n_levels == 0 || symbol > self.sigma {
+            return None;
+        }
+
+        let mut path_off = Vec::with_capacity(self.n_levels);
+        let mut rank_path_off = Vec::with_capacity(self.n_levels);
+
+        let mut b = 0usize;
+        let mut shift: i64 = 2 * (self.n_levels - 1) as i64;
+
+        for level in 0..self.n_levels {
+            path_off.push(b);
+            let two_bits = (symbol >> shift as usize).as_() & 3;
+            let lv = &self.levels[level];
+            if b > lv.len() {
+                return None;
+            }
+            let rank_b = unsafe { lv.rank_unchecked(two_bits as u8, b) };
+            b = rank_b + unsafe { lv.occs_smaller_unchecked(two_bits as u8) };
+            shift -= 2;
+            rank_path_off.push(rank_b);
+        }
+
+        shift = 0;
+        let mut result = i;
+        for level in (0..self.n_levels).rev() {
+            b = path_off[level];
+            let rank_b = rank_path_off[level];
+            let two_bits = (symbol >> shift as usize).as_() & 3;
+            let lv = &self.levels[level];
+            result = lv.select(two_bits as u8, rank_b + result)? - b;
+            shift += 2;
+        }
+
+        Some(result)
+    }
+
+    #[inline(always)]
+    unsafe fn select_unchecked(&self, symbol: Self::Item, i: usize) -> usize {
+        self.select(symbol, i).unwrap()
+    }
+}
+
+// ── Huffman QWT view ────────────────────────────────────────────────────────
+
+/// Borrowing Huffman quad wavelet tree over an `HQWB` blob.
+///
+/// Level RSQ payloads are borrowed; Huffman code tables are owned (small).
+#[derive(Clone, Debug)]
+pub struct HqwtView<'a, T, const B_SIZE: usize = 256> {
+    n: usize,
+    n_levels: usize,
+    codes_encode: Vec<PrefixCode>,
+    codes_decode: Vec<Vec<(u32, T)>>,
+    levels: Vec<RSQVectorView<'a, B_SIZE>>,
+    /// Per-level sequence length (HQWT uneven levels).
+    lens: Vec<usize>,
+    _marker: PhantomData<&'a [u8]>,
+}
+
+impl<'a, T, const B_SIZE: usize> HqwtView<'a, T, B_SIZE>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+    u8: AsPrimitive<T>,
+{
+    /// Open a zero-copy view over an `HQWB` blob.
+    pub fn from_bytes(bytes: &'a [u8]) -> Result<Self, LayoutError> {
+        ensure_le()?;
+        if bytes.len() < HEADER_SIZE {
+            return Err(LayoutError::Truncated);
+        }
+        if &bytes[0..4] != HQWB_MAGIC {
+            return Err(LayoutError::BadMagic);
+        }
+        let mut o = 4;
+        let version = get_u16(bytes, &mut o);
+        if version != FORMAT_VERSION {
+            return Err(LayoutError::BadVersion);
+        }
+        let flags = bytes[o];
+        o += 1;
+        if flags & FLAG_PREFETCH != 0 {
+            return Err(LayoutError::PrefetchNotSupported);
+        }
+        let want_b512 = flags & FLAG_B512 != 0;
+        if (B_SIZE == 512) != want_b512 {
+            return Err(LayoutError::Inconsistent {
+                detail: "B_SIZE flag does not match requested type",
+            });
+        }
+        let t_width = bytes[o];
+        o += 1;
+        if t_width as usize != size_of::<T>() {
+            return Err(LayoutError::Inconsistent {
+                detail: "t_width does not match T",
+            });
+        }
+        let n = get_u64(bytes, &mut o) as usize;
+        let n_levels = get_u16(bytes, &mut o) as usize;
+        let encode_len = get_u16(bytes, &mut o) as usize;
+        let decode_n_buckets = get_u16(bytes, &mut o) as usize;
+        let _ = o;
+
+        let dir_end = HEADER_SIZE + n_levels * HQWT_LEVEL_DIR_SIZE;
+        if bytes.len() < dir_end {
+            return Err(LayoutError::Truncated);
+        }
+
+        // Code tables (owned) — after directory, 8-aligned.
+        let mut p = align_up(dir_end, 8);
+        let encode_bytes = encode_len * 8;
+        if p + encode_bytes > bytes.len() {
+            return Err(LayoutError::Truncated);
+        }
+        let mut codes_encode = Vec::with_capacity(encode_len);
+        for i in 0..encode_len {
+            let base = p + i * 8;
+            let content = u32::from_le_bytes(bytes[base..base + 4].try_into().unwrap());
+            let len = u32::from_le_bytes(bytes[base + 4..base + 8].try_into().unwrap());
+            codes_encode.push(PrefixCode { content, len });
+        }
+        p += encode_bytes;
+
+        let mut codes_decode: Vec<Vec<(u32, T)>> = Vec::with_capacity(decode_n_buckets);
+        for _ in 0..decode_n_buckets {
+            if p + 4 > bytes.len() {
+                return Err(LayoutError::Truncated);
+            }
+            let n_entries = u32::from_le_bytes(bytes[p..p + 4].try_into().unwrap()) as usize;
+            p += 4;
+            let need = n_entries * 12;
+            if p + need > bytes.len() {
+                return Err(LayoutError::Truncated);
+            }
+            let mut bucket = Vec::with_capacity(n_entries);
+            for _ in 0..n_entries {
+                let content = u32::from_le_bytes(bytes[p..p + 4].try_into().unwrap());
+                p += 4;
+                let sym_u = u64::from_le_bytes(bytes[p..p + 8].try_into().unwrap()) as usize;
+                p += 8;
+                bucket.push((content, sym_u.as_()));
+            }
+            codes_decode.push(bucket);
+        }
+
+        let mut levels = Vec::with_capacity(n_levels);
+        let mut lens = Vec::with_capacity(n_levels);
+        for li in 0..n_levels {
+            let dir_off = HEADER_SIZE + li * HQWT_LEVEL_DIR_SIZE;
+            let dir = HqwtLevelDir::read(&bytes[dir_off..dir_off + HQWT_LEVEL_DIR_SIZE])?;
+            levels.push(RSQVectorView::from_dir(bytes, &dir.plain)?);
+            lens.push(dir.level_len as usize);
+        }
+
+        Ok(Self {
+            n,
+            n_levels,
+            codes_encode,
+            codes_decode,
+            levels,
+            lens,
+            _marker: PhantomData,
+        })
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.n
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.n == 0
+    }
+
+    #[inline]
+    pub fn n_levels(&self) -> usize {
+        self.n_levels
+    }
+
+    #[inline]
+    pub fn levels(&self) -> &[RSQVectorView<'a, B_SIZE>] {
+        &self.levels
+    }
+
+    #[inline]
+    pub fn codes_encode(&self) -> &[PrefixCode] {
+        &self.codes_encode
+    }
+
+    #[inline]
+    pub fn codes_decode(&self) -> &[Vec<(u32, T)>] {
+        &self.codes_decode
+    }
+
+    #[inline]
+    pub fn level_lens(&self) -> &[usize] {
+        &self.lens
+    }
+}
+
+impl<'a, T, const B_SIZE: usize> AccessUnsigned for HqwtView<'a, T, B_SIZE>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+{
+    type Item = T;
+
+    #[inline(always)]
+    fn get(&self, i: usize) -> Option<Self::Item> {
+        if i >= self.n {
+            return None;
+        }
+        Some(unsafe { self.get_unchecked(i) })
+    }
+
+    #[inline(always)]
+    unsafe fn get_unchecked(&self, i: usize) -> Self::Item {
+        let mut cur_i = i;
+        let mut result: u32 = 0;
+        let mut shift = 0usize;
+
+        for level in 0..self.n_levels {
+            if cur_i >= self.lens[level] {
+                break;
+            }
+            let lv = &self.levels[level];
+            let symbol = lv.get_unchecked(cur_i);
+            result = (result << 2) | symbol as u32;
+            let offset = lv.occs_smaller_unchecked(symbol);
+            cur_i = lv.rank_unchecked(symbol, cur_i) + offset;
+            shift += 2;
+        }
+
+        let idx = self.codes_decode[shift]
+            .binary_search_by_key(&result, |(x, _)| *x)
+            .expect("could not translate symbol");
+        T::from(self.codes_decode[shift][idx].1).unwrap()
+    }
+}
+
+impl<'a, T, const B_SIZE: usize> RankUnsigned for HqwtView<'a, T, B_SIZE>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+{
+    #[inline(always)]
+    fn rank(&self, symbol: Self::Item, i: usize) -> Option<usize> {
+        if i > self.n
+            || symbol.as_() >= self.codes_encode.len()
+            || self.codes_encode[symbol.as_()].len == 0
+        {
+            return None;
+        }
+        Some(unsafe { self.rank_unchecked(symbol, i) })
+    }
+
+    #[inline(always)]
+    unsafe fn rank_unchecked(&self, symbol: Self::Item, i: usize) -> usize {
+        let mut cur_i = i;
+        let mut cur_p = 0usize;
+        let code = &self.codes_encode[symbol.as_()];
+        let mut shift: i64 = code.len as i64 - 2;
+        let repr = code.content;
+        let mut level = 0usize;
+
+        while shift >= 0 {
+            let two_bits = ((repr >> shift as usize) & 3) as u8;
+            let lv = &self.levels[level];
+            let offset = lv.occs_smaller_unchecked(two_bits);
+            cur_p = lv.rank_unchecked(two_bits, cur_p) + offset;
+            cur_i = lv.rank_unchecked(two_bits, cur_i) + offset;
+            level += 1;
+            shift -= 2;
+        }
+        cur_i - cur_p
+    }
+}
+
+impl<'a, T, const B_SIZE: usize> SelectUnsigned for HqwtView<'a, T, B_SIZE>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+{
+    #[inline(always)]
+    fn select(&self, symbol: Self::Item, i: usize) -> Option<usize> {
+        if symbol.as_() >= self.codes_encode.len() || self.codes_encode[symbol.as_()].len == 0 {
+            return None;
+        }
+
+        let mut path_off = Vec::with_capacity(self.n_levels);
+        let mut rank_path_off = Vec::with_capacity(self.n_levels);
+
+        let code = &self.codes_encode[symbol.as_()];
+        let mut shift: i64 = code.len as i64 - 2;
+        let repr = code.content;
+        let mut b = 0usize;
+        let mut level = 0usize;
+
+        while shift >= 0 {
+            path_off.push(b);
+            let two_bits = ((repr >> shift as usize) & 3) as u8;
+            let lv = &self.levels[level];
+            if b > lv.len() {
+                return None;
+            }
+            let rank_b = unsafe { lv.rank_unchecked(two_bits, b) };
+            b = rank_b + unsafe { lv.occs_smaller_unchecked(two_bits) };
+            rank_path_off.push(rank_b);
+            level += 1;
+            shift -= 2;
+        }
+
+        shift = 0;
+        let mut result = i;
+        for lvl in (0..level).rev() {
+            b = path_off[lvl];
+            let rank_b = rank_path_off[lvl];
+            let two_bits = ((repr >> shift as usize) & 3) as u8;
+            let lv = &self.levels[lvl];
+            result = lv.select(two_bits, rank_b + result)? - b;
+            shift += 2;
+        }
+        Some(result)
+    }
+
+    #[inline(always)]
+    unsafe fn select_unchecked(&self, symbol: Self::Item, i: usize) -> usize {
+        self.select(symbol, i).unwrap()
+    }
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+#[inline]
+fn get_u16(buf: &[u8], o: &mut usize) -> u16 {
+    let v = u16::from_le_bytes(buf[*o..*o + 2].try_into().unwrap());
+    *o += 2;
+    v
+}
+
+#[inline]
+fn get_u64(buf: &[u8], o: &mut usize) -> u64 {
+    let v = u64::from_le_bytes(buf[*o..*o + 8].try_into().unwrap());
+    *o += 8;
+    v
+}
+
+/// Owned byte buffer whose usable slice is 64-byte aligned.
+///
+/// Zero-copy views require absolute alignment of POD arrays. A plain
+/// `Vec<u8>` from `to_bytes` is typically only 8-aligned; wrap it here
+/// before opening a view (mmap'd pages are naturally page-aligned).
+pub struct AlignedBytes {
+    buf: Vec<u8>,
+    start: usize,
+    len: usize,
+}
+
+impl AlignedBytes {
+    /// Copy `src` into an over-allocated buffer and expose a 64-aligned window.
+    pub fn from_slice(src: &[u8]) -> Self {
+        if src.is_empty() {
+            return Self {
+                buf: Vec::new(),
+                start: 0,
+                len: 0,
+            };
+        }
+        // Over-allocate so a 64-aligned subslice of length `src.len()` fits.
+        let mut buf = vec![0u8; src.len() + 63];
+        let base = buf.as_ptr() as usize;
+        let start = align_up(base, 64) - base;
+        debug_assert!(start + src.len() <= buf.len());
+        buf[start..start + src.len()].copy_from_slice(src);
+        // Confirm alignment still holds (Vec must not have reallocated).
+        debug_assert_eq!((buf.as_ptr() as usize + start) % 64, 0);
+        Self {
+            buf,
+            start,
+            len: src.len(),
+        }
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.buf[self.start..self.start + self.len]
+    }
+}
+
+impl std::ops::Deref for AlignedBytes {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bytes::{hqwt256_to_bytes, qwt256_to_bytes};
+    use crate::{HQWT256, QWT256};
+
+    #[test]
+    fn qwt_view_matches_owned() {
+        let data: Vec<u32> = (0..1000).map(|x| (x * 3) % 128).collect();
+        let original = QWT256::from(data.clone());
+        let bytes = qwt256_to_bytes(&original).unwrap();
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let view: QwtView<'_, u32, 256> = QwtView::from_bytes(aligned.as_slice()).unwrap();
+
+        assert_eq!(view.len(), original.len());
+        assert_eq!(view.n_levels(), original.n_levels());
+        assert_eq!(view.sigma_raw(), original.sigma_raw());
+
+        for i in 0..data.len() {
+            assert_eq!(view.get(i), original.get(i), "get@{i}");
+        }
+        for &sym in &[0u32, 1, 5, 64, 127] {
+            for i in (0..=data.len()).step_by(31) {
+                assert_eq!(view.rank(sym, i), original.rank(sym, i), "rank({sym},{i})");
+            }
+            if let Some(cnt) = original.rank(sym, data.len()) {
+                for k in 0..cnt.min(3) {
+                    assert_eq!(
+                        view.select(sym, k),
+                        original.select(sym, k),
+                        "select({sym},{k})"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn qwt_view_empty() {
+        let mut empty: Vec<u32> = vec![];
+        let original = QWT256::new(&mut empty);
+        let bytes = qwt256_to_bytes(&original).unwrap();
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let view: QwtView<'_, u32, 256> = QwtView::from_bytes(aligned.as_slice()).unwrap();
+        assert_eq!(view.len(), 0);
+        assert!(view.is_empty());
+        assert_eq!(view.n_levels(), 0);
+        assert_eq!(view.get(0), None);
+    }
+
+    #[test]
+    fn qwt_view_rejects_unaligned_base() {
+        // Build a blob, then force the slice start to be 1-mod-64 so cast fails
+        // when there is at least one level with POD payload.
+        let original = QWT256::from(vec![1u32, 2, 3, 4, 5, 6, 7, 8]);
+        let bytes = qwt256_to_bytes(&original).unwrap();
+        // Pad so we can take an unaligned window that still has the full blob.
+        let mut padded = vec![0u8; 1];
+        padded.extend_from_slice(&bytes);
+        // padded[1..] has base = padded.as_ptr()+1. If that is not 64-aligned
+        // (almost always), from_bytes should fail with Misaligned when casting.
+        let slice = &padded[1..];
+        let addr = slice.as_ptr() as usize;
+        if addr % 64 != 0 && original.n_levels() > 0 {
+            let err = QwtView::<u32, 256>::from_bytes(slice).unwrap_err();
+            assert_eq!(err, LayoutError::Misaligned);
+        }
+    }
+
+    #[test]
+    fn hqwt_view_matches_owned() {
+        let data: Vec<u32> = (0..500).map(|x| (x * 7) % 64).collect();
+        let original = HQWT256::from(data.clone());
+        let bytes = hqwt256_to_bytes(&original).unwrap();
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let view: HqwtView<'_, u32, 256> = HqwtView::from_bytes(aligned.as_slice()).unwrap();
+
+        assert_eq!(view.len(), original.len());
+        assert_eq!(view.n_levels(), original.n_levels());
+
+        for i in 0..data.len() {
+            assert_eq!(view.get(i), original.get(i), "get@{i}");
+        }
+        for &sym in &[0u32, 1, 7, 31, 63] {
+            for i in (0..=data.len()).step_by(29) {
+                assert_eq!(view.rank(sym, i), original.rank(sym, i), "rank({sym},{i})");
+            }
+            if let Some(cnt) = original.rank(sym, data.len()) {
+                for k in 0..cnt.min(3) {
+                    assert_eq!(
+                        view.select(sym, k),
+                        original.select(sym, k),
+                        "select({sym},{k})"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn hqwt_view_empty() {
+        let mut empty: Vec<u32> = vec![];
+        let original = HQWT256::new(&mut empty);
+        let bytes = hqwt256_to_bytes(&original).unwrap();
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let view: HqwtView<'_, u32, 256> = HqwtView::from_bytes(aligned.as_slice()).unwrap();
+        assert_eq!(view.len(), 0);
+        assert!(view.is_empty());
+    }
+
+    #[test]
+    fn hqwt_view_bad_magic() {
+        let bytes = hqwt256_to_bytes(&HQWT256::from(vec![1u32, 2, 3])).unwrap();
+        // Corrupt magic in a fresh aligned copy.
+        let mut raw = bytes.clone();
+        raw[0] = b'X';
+        let aligned = AlignedBytes::from_slice(&raw);
+        let err = HqwtView::<u32, 256>::from_bytes(aligned.as_slice()).unwrap_err();
+        assert_eq!(err, LayoutError::BadMagic);
+    }
+}
+

--- a/src/bytes/view.rs
+++ b/src/bytes/view.rs
@@ -15,6 +15,8 @@ use crate::{AccessUnsigned, RankUnsigned, SelectUnsigned};
 use num_traits::AsPrimitive;
 use std::marker::PhantomData;
 use std::mem::size_of;
+use std::ops::Range;
+
 
 // ── Plain QWT view ──────────────────────────────────────────────────────────
 
@@ -125,9 +127,272 @@ where
     pub fn levels(&self) -> &[RSQVectorView<'a, B_SIZE>] {
         &self.levels
     }
+
+    /// Returns the symbol at position `i` together with `rank(symbol, i + 1)`
+    /// (occurrences of that symbol in `0..=i`) in a single tree descent.
+    ///
+    /// Equivalent to `(get(i), rank(get(i), i + 1))` but shares the wavelet
+    /// path for both queries. Returns `None` if `i` is out of bounds.
+    #[inline(always)]
+    #[must_use]
+    pub fn get_and_rank(&self, i: usize) -> Option<(T, usize)> {
+        if i >= self.n || self.n_levels == 0 {
+            return None;
+        }
+        // SAFETY: bounds checked above
+        Some(unsafe { self.get_and_rank_unchecked(i) })
+    }
+
+    /// Returns the symbol at position `i` together with `rank(symbol, i + 1)`
+    /// in a single tree descent.
+    ///
+    /// # Safety
+    /// Calling this method with an out-of-bounds index is undefined behavior.
+    #[inline(always)]
+    #[must_use]
+    pub unsafe fn get_and_rank_unchecked(&self, i: usize) -> (T, usize) {
+        let mut result = T::zero();
+        let mut cur_i = i;
+        let mut cur_p = 0usize;
+
+        for level in 0..self.n_levels - 1 {
+            let lv = &self.levels[level];
+            let symbol = lv.get_unchecked(cur_i);
+            result = (result << 2) | (symbol as usize).as_();
+            let offset = lv.occs_smaller_unchecked(symbol);
+            cur_p = lv.rank_unchecked(symbol, cur_p) + offset;
+            cur_i = lv.rank_unchecked(symbol, cur_i) + offset;
+        }
+
+        let last = self.n_levels - 1;
+        let lv = &self.levels[last];
+        let symbol = lv.get_unchecked(cur_i);
+        let result = (result << 2) | (symbol as usize).as_();
+        // rank(c, i) on the last level (no occs offset), then +1 → rank(c, i+1)
+        let r_i = lv.rank_unchecked(symbol, cur_i);
+        let r_p = lv.rank_unchecked(symbol, cur_p);
+        let rank_inclusive = r_i - r_p + 1;
+        (result, rank_inclusive)
+    }
+
+    /// Bulk-extract symbols in a contiguous position range as an **ascending
+    /// multiset** (sorted by symbol value, with multiplicity).
+    ///
+    /// This is **not** position order: the output is algebraically equal to
+    /// sorting the multiset `{ get(i) | i ∈ range }`, not to iterating
+    /// `get` over the range in index order.
+    ///
+    /// Implementation walks the wavelet tree level-by-level, partitioning each
+    /// contiguous range into at most four child ranges (one per 2-bit digit)
+    /// via `rank_all` + `occs_smaller`. Singleton ranges short-circuit to a single
+    /// remaining-path descent. Empty / out-of-bounds ranges return an empty
+    /// vector.
+    #[inline]
+    #[must_use]
+    pub fn extract_range(&self, range: Range<usize>) -> Vec<T> {
+        if range.start >= range.end || range.end > self.n || self.n_levels == 0 {
+            return Vec::new();
+        }
+        let n = range.end - range.start;
+        let mut out = vec![T::zero(); n];
+        // SAFETY: range is in-bounds on the top level; child ranges stay valid
+        // by wavelet matrix invariants.
+        unsafe {
+            self.extract_range_sorted_rec(0, range.start, range.end, T::zero(), &mut out);
+        }
+        out
+    }
+
+    /// Bulk-extract **ascending distinct** symbols for a contiguous position
+    /// range (one entry per unique value, sorted).
+    ///
+    /// Same expand-tree as [`Self::extract_range`], but leaf digit runs emit a
+    /// single symbol instead of `count` copies — no intermediate multiset and
+    /// no post-dedup pass. Algebraically equal to sort+dedup of per-row
+    /// [`AccessUnsigned::get`] over the range.
+    ///
+    /// Empty / out-of-bounds ranges return an empty vector.
+    #[inline]
+    #[must_use]
+    pub fn extract_range_distinct(&self, range: Range<usize>) -> Vec<T> {
+        let mut out = Vec::new();
+        self.extract_range_distinct_into(range, &mut out);
+        out
+    }
+
+    /// Like [`Self::extract_range_distinct`], writing into `out` (cleared first).
+    ///
+    /// Prefer this when the caller owns a reusable buffer.
+    #[inline]
+    pub fn extract_range_distinct_into(&self, range: Range<usize>, out: &mut Vec<T>) {
+        out.clear();
+        if range.start >= range.end || range.end > self.n || self.n_levels == 0 {
+            return;
+        }
+        out.reserve(range.end - range.start);
+        // SAFETY: range is in-bounds on the top level.
+        unsafe {
+            self.extract_range_distinct_rec(0, range.start, range.end, T::zero(), out);
+        }
+    }
+
+    /// Finish one remaining position starting at `level` with path `prefix`.
+    ///
+    /// Used when a child range has `count == 1` so we avoid expanding a 4-way
+    /// tree for a singleton.
+    #[inline]
+    unsafe fn extract_singleton_from(&self, mut level: usize, mut pos: usize, mut prefix: T) -> T {
+        while level + 1 < self.n_levels {
+            let lv = &self.levels[level];
+            let dig = lv.get_unchecked(pos);
+            prefix = (prefix << 2) | (dig as usize).as_();
+            let offset = lv.occs_smaller_unchecked(dig);
+            pos = lv.rank_unchecked(dig, pos) + offset;
+            level += 1;
+        }
+        let dig = self.levels[level].get_unchecked(pos);
+        (prefix << 2) | (dig as usize).as_()
+    }
+
+    /// Recursive sorted multiset fill: write ascending symbols into `out`.
+    ///
+    /// # Safety
+    /// `start..end` must be a valid contiguous range at `level` of the wavelet
+    /// matrix; `out.len() == end - start`.
+    unsafe fn extract_range_sorted_rec(
+        &self,
+        level: usize,
+        start: usize,
+        end: usize,
+        prefix: T,
+        out: &mut [T],
+    ) {
+        debug_assert_eq!(out.len(), end - start);
+        if start >= end {
+            return;
+        }
+        // Singleton short-circuit: one position → single descent.
+        if end - start == 1 {
+            out[0] = self.extract_singleton_from(level, start, prefix);
+            return;
+        }
+
+        let lv = &self.levels[level];
+        let last = level + 1 == self.n_levels;
+
+        // Partition [start, end) by 2-bit digit via rank_all at both ends.
+        // SAFETY: start/end valid at this level by caller contract.
+        let ranks_s = lv.rank_all_unchecked(start);
+        let ranks_e = lv.rank_all_unchecked(end);
+        let counts = [
+            ranks_e[0] - ranks_s[0],
+            ranks_e[1] - ranks_s[1],
+            ranks_e[2] - ranks_s[2],
+            ranks_e[3] - ranks_s[3],
+        ];
+
+        if last {
+            // Fill runs of (prefix<<2)|b by digit order — already ascending.
+            let mut off = 0usize;
+            for (b, &cnt) in counts.iter().enumerate() {
+                if cnt == 0 {
+                    continue;
+                }
+                let sym: T = (prefix << 2) | b.as_();
+                out[off..off + cnt].fill(sym);
+                off += cnt;
+            }
+            debug_assert_eq!(off, out.len());
+            return;
+        }
+
+        // Partition out into digit-order child slices (no intermediate Vecs).
+        let mut off = 0usize;
+        for (b, &cnt) in counts.iter().enumerate() {
+            if cnt == 0 {
+                continue;
+            }
+            // SAFETY: b in 0..4
+            let offset = lv.occs_smaller_unchecked(b as u8);
+            let child_start = offset + ranks_s[b];
+            let child_end = child_start + cnt;
+            let child_prefix: T = (prefix << 2) | b.as_();
+            self.extract_range_sorted_rec(
+                level + 1,
+                child_start,
+                child_end,
+                child_prefix,
+                &mut out[off..off + cnt],
+            );
+            off += cnt;
+        }
+        debug_assert_eq!(off, out.len());
+    }
+
+    /// Recursive ascending-distinct emit into `out`.
+    ///
+    /// # Safety
+    /// `start..end` must be a valid contiguous range at `level`.
+    unsafe fn extract_range_distinct_rec(
+        &self,
+        level: usize,
+        start: usize,
+        end: usize,
+        prefix: T,
+        out: &mut Vec<T>,
+    ) {
+        if start >= end {
+            return;
+        }
+        if end - start == 1 {
+            out.push(self.extract_singleton_from(level, start, prefix));
+            return;
+        }
+
+        let lv = &self.levels[level];
+        let last = level + 1 == self.n_levels;
+
+        // SAFETY: start/end valid at this level by caller contract.
+        let ranks_s = lv.rank_all_unchecked(start);
+        let ranks_e = lv.rank_all_unchecked(end);
+        let counts = [
+            ranks_e[0] - ranks_s[0],
+            ranks_e[1] - ranks_s[1],
+            ranks_e[2] - ranks_s[2],
+            ranks_e[3] - ranks_s[3],
+        ];
+
+        if last {
+            for (b, &cnt) in counts.iter().enumerate() {
+                if cnt != 0 {
+                    let sym: T = (prefix << 2) | b.as_();
+                    out.push(sym);
+                }
+            }
+            return;
+        }
+
+        for (b, &cnt) in counts.iter().enumerate() {
+            if cnt == 0 {
+                continue;
+            }
+            let offset = lv.occs_smaller_unchecked(b as u8);
+            let child_start = offset + ranks_s[b];
+            let child_end = child_start + cnt;
+            let child_prefix: T = (prefix << 2) | b.as_();
+            self.extract_range_distinct_rec(
+                level + 1,
+                child_start,
+                child_end,
+                child_prefix,
+                out,
+            );
+        }
+    }
 }
 
 impl<'a, T, const B_SIZE: usize> AccessUnsigned for QwtView<'a, T, B_SIZE>
+
 where
     T: WTIndexable,
     usize: AsPrimitive<T>,
@@ -719,4 +984,131 @@ mod tests {
         let err = HqwtView::<u32, 256>::from_bytes(aligned.as_slice()).unwrap_err();
         assert_eq!(err, LayoutError::BadMagic);
     }
+
+    // ── extract / get_and_rank differential (view ↔ heap) ────────────────
+
+    #[test]
+    fn qwt_view_extract_matches_owned() {
+        let data: Vec<u32> = (0..500).map(|x| (x * 7) % 64).collect();
+        let original = QWT256::from(data.clone());
+        let bytes = qwt256_to_bytes(&original).unwrap();
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let view: QwtView<'_, u32, 256> = QwtView::from_bytes(aligned.as_slice()).unwrap();
+        let n = data.len();
+
+        // full range
+        assert_eq!(view.extract_range(0..n), original.extract_range(0..n));
+        assert_eq!(
+            view.extract_range_distinct(0..n),
+            original.extract_range_distinct(0..n)
+        );
+
+        // empty / oob
+        assert!(view.extract_range(0..0).is_empty());
+        assert!(view.extract_range(n..n).is_empty());
+        assert!(view.extract_range(0..n + 1).is_empty());
+        let reversed = std::ops::Range { start: 3, end: 2 };
+        assert!(view.extract_range(reversed).is_empty());
+
+        // subrange sweep
+        for start in (0..=n).step_by(37) {
+            for end in (start..=n).step_by(41) {
+                let got = view.extract_range(start..end);
+                let exp = original.extract_range(start..end);
+                assert_eq!(got, exp, "multiset mismatch for {start}..{end}");
+
+                let got_d = view.extract_range_distinct(start..end);
+                let exp_d = original.extract_range_distinct(start..end);
+                assert_eq!(got_d, exp_d, "distinct mismatch for {start}..{end}");
+
+                // into API
+                let mut buf = vec![99u32; 3];
+                view.extract_range_distinct_into(start..end, &mut buf);
+                assert_eq!(buf, exp_d);
+
+                // also equals sort / sort+dedup of per-row get
+                let mut per_row: Vec<_> = (start..end).map(|i| view.get(i).unwrap()).collect();
+                per_row.sort_unstable();
+                assert_eq!(got, per_row);
+                let mut deduped = per_row.clone();
+                deduped.dedup();
+                assert_eq!(got_d, deduped);
+            }
+        }
+
+        // singleton
+        if n > 0 {
+            assert_eq!(view.extract_range(0..1), original.extract_range(0..1));
+            assert_eq!(
+                view.extract_range_distinct(0..1),
+                original.extract_range_distinct(0..1)
+            );
+        }
+    }
+
+    #[test]
+    fn qwt_view_get_and_rank_matches_owned() {
+        let data: Vec<u32> = (0..300).map(|x| (x * 11) % 128).collect();
+        let original = QWT256::from(data.clone());
+        let bytes = qwt256_to_bytes(&original).unwrap();
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let view: QwtView<'_, u32, 256> = QwtView::from_bytes(aligned.as_slice()).unwrap();
+
+        assert_eq!(view.get_and_rank(data.len()), None);
+        assert_eq!(original.get_and_rank(data.len()), None);
+
+        for i in 0..data.len() {
+            let v = view.get_and_rank(i).unwrap();
+            let o = original.get_and_rank(i).unwrap();
+            assert_eq!(v, o, "get_and_rank@{i}");
+            // also matches get + rank(get, i+1)
+            let sym = view.get(i).unwrap();
+            assert_eq!(v.0, sym);
+            assert_eq!(v.1, view.rank(sym, i + 1).unwrap());
+        }
+    }
+
+    #[test]
+    fn qwt_view_extract_empty_tree() {
+        let mut empty: Vec<u32> = vec![];
+        let original = QWT256::new(&mut empty);
+        let bytes = qwt256_to_bytes(&original).unwrap();
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let view: QwtView<'_, u32, 256> = QwtView::from_bytes(aligned.as_slice()).unwrap();
+        assert!(view.extract_range(0..0).is_empty());
+        assert!(view.extract_range_distinct(0..0).is_empty());
+        assert_eq!(view.get_and_rank(0), None);
+    }
+
+    #[test]
+    fn qwt_view_extract_large_alphabet() {
+        let data: Vec<u32> = (0..800).map(|x| (x * 13) % 4000).collect();
+        let original = QWT256::from(data.clone());
+        let bytes = qwt256_to_bytes(&original).unwrap();
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let view: QwtView<'_, u32, 256> = QwtView::from_bytes(aligned.as_slice()).unwrap();
+        let n = data.len();
+
+        for &(start, end) in &[(0, n), (0, 1), (n / 3, 2 * n / 3), (n - 1, n), (10, 50)] {
+            assert_eq!(
+                view.extract_range(start..end),
+                original.extract_range(start..end),
+                "multiset {start}..{end}"
+            );
+            assert_eq!(
+                view.extract_range_distinct(start..end),
+                original.extract_range_distinct(start..end),
+                "distinct {start}..{end}"
+            );
+        }
+
+        for i in (0..n).step_by(23) {
+            assert_eq!(
+                view.get_and_rank(i),
+                original.get_and_rank(i),
+                "get_and_rank@{i}"
+            );
+        }
+    }
 }
+

--- a/src/bytes/view.rs
+++ b/src/bytes/view.rs
@@ -934,6 +934,41 @@ mod tests {
     }
 
     #[test]
+    fn qwt_view_rejects_non_monotone_child_offsets() {
+        let original = QWT256::from((0..1000).map(|x| (x * 3) % 64).collect::<Vec<u32>>());
+        let mut bytes = qwt256_to_bytes(&original).unwrap();
+        // First LevelDir.n_occs_smaller[0] must be zero.
+        bytes[HEADER_SIZE + 88..HEADER_SIZE + 96].copy_from_slice(&1u64.to_le_bytes());
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let error = QwtView::<u32, 256>::from_bytes(aligned.as_slice()).unwrap_err();
+        assert!(matches!(error, LayoutError::Inconsistent { .. }));
+    }
+
+    #[test]
+    fn qwt_view_rejects_missing_select_sentinels() {
+        let original = QWT256::from((0..1000).map(|x| (x * 3) % 64).collect::<Vec<u32>>());
+        let mut bytes = qwt256_to_bytes(&original).unwrap();
+        // First LevelDir.n_sel[0] must include the initial sample and sentinel.
+        bytes[HEADER_SIZE + 72..HEADER_SIZE + 76].copy_from_slice(&1u32.to_le_bytes());
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let error = QwtView::<u32, 256>::from_bytes(aligned.as_slice()).unwrap_err();
+        assert!(matches!(error, LayoutError::Inconsistent { .. }));
+    }
+
+    #[test]
+    fn qwt_view_rejects_out_of_bounds_rank_metadata() {
+        let original = QWT256::from((0..1000).map(|x| (x * 3) % 64).collect::<Vec<u32>>());
+        let mut bytes = qwt256_to_bytes(&original).unwrap();
+        let sb_field = HEADER_SIZE + 24;
+        let sb_offset =
+            u64::from_le_bytes(bytes[sb_field..sb_field + 8].try_into().unwrap()) as usize;
+        bytes[sb_offset..sb_offset + 16].fill(0xff);
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let error = QwtView::<u32, 256>::from_bytes(aligned.as_slice()).unwrap_err();
+        assert!(matches!(error, LayoutError::Inconsistent { .. }));
+    }
+
+    #[test]
     fn hqwt_view_matches_owned() {
         let data: Vec<u32> = (0..500).map(|x| (x * 7) % 64).collect();
         let original = HQWT256::from(data.clone());
@@ -1110,5 +1145,5 @@ mod tests {
             );
         }
     }
-}
 
+}

--- a/src/bytes/view.rs
+++ b/src/bytes/view.rs
@@ -11,12 +11,12 @@ use super::{
 };
 use crate::quadwt::huffqwt::PrefixCode;
 use crate::quadwt::WTIndexable;
-use crate::{AccessUnsigned, RankUnsigned, SelectUnsigned};
+use crate::utils::msb;
+use crate::{AccessUnsigned, RankQuad, RankUnsigned, SelectUnsigned, MAX_QUAD_LEVELS};
 use num_traits::AsPrimitive;
 use std::marker::PhantomData;
 use std::mem::size_of;
 use std::ops::Range;
-
 
 // ── Plain QWT view ──────────────────────────────────────────────────────────
 
@@ -82,7 +82,22 @@ where
         let n_levels = get_u16(bytes, &mut o) as usize;
         let _ = o;
 
-        let dir_end = HEADER_SIZE + n_levels * LEVEL_DIR_SIZE;
+        let max_type_levels = (size_of::<T>() * u8::BITS as usize).div_ceil(2);
+        if sigma.as_() != sigma_u
+            || n_levels > MAX_QUAD_LEVELS
+            || n_levels > max_type_levels
+            || (n > 0 && n_levels == 0)
+            || (n == 0 && (n_levels != 0 || sigma != T::zero()))
+        {
+            return Err(LayoutError::Inconsistent {
+                detail: "plain QWT level count is invalid",
+            });
+        }
+
+        let dir_end = n_levels
+            .checked_mul(LEVEL_DIR_SIZE)
+            .and_then(|size| HEADER_SIZE.checked_add(size))
+            .ok_or(LayoutError::Truncated)?;
         if bytes.len() < dir_end {
             return Err(LayoutError::Truncated);
         }
@@ -93,14 +108,56 @@ where
             let dir = LevelDir::read(&bytes[dir_off..dir_off + LEVEL_DIR_SIZE])?;
             levels.push(RSQVectorView::from_dir(bytes, &dir)?);
         }
+        if levels.iter().any(|level| level.len() != n) {
+            return Err(LayoutError::Inconsistent {
+                detail: "plain QWT level length disagrees with header length",
+            });
+        }
 
-        Ok(Self {
+        if n > 0 && n_levels != (msb(sigma) + 1).div_ceil(2) as usize {
+            return Err(LayoutError::Inconsistent {
+                detail: "plain QWT level count disagrees with sigma",
+            });
+        }
+
+        let view = Self {
             n,
             n_levels,
             sigma,
             levels,
             _marker: PhantomData,
-        })
+        };
+        if n > 0 {
+            let mut actual_sigma = T::zero();
+            let mut start = 0usize;
+            let mut end = n;
+            for (level_index, level) in view.levels.iter().enumerate() {
+                // SAFETY: the top-level interval is `0..n`; each child
+                // interval is derived from validated ranks and child offsets.
+                let ranks_start = unsafe { level.rank_all_unchecked(start) };
+                let ranks_end = unsafe { level.rank_all_unchecked(end) };
+                let Some(digit) = (0..4)
+                    .rev()
+                    .find(|&digit| ranks_end[digit] > ranks_start[digit])
+                else {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "plain QWT maximum path is empty",
+                    });
+                };
+                actual_sigma = (actual_sigma << 2) | digit.as_();
+                if level_index + 1 < n_levels {
+                    let offset = level.n_occs_smaller()[digit];
+                    start = offset + ranks_start[digit];
+                    end = offset + ranks_end[digit];
+                }
+            }
+            if actual_sigma != sigma {
+                return Err(LayoutError::Inconsistent {
+                    detail: "plain QWT sigma disagrees with encoded payload",
+                });
+            }
+        }
+        Ok(view)
     }
 
     #[inline]
@@ -380,19 +437,12 @@ where
             let child_start = offset + ranks_s[b];
             let child_end = child_start + cnt;
             let child_prefix: T = (prefix << 2) | b.as_();
-            self.extract_range_distinct_rec(
-                level + 1,
-                child_start,
-                child_end,
-                child_prefix,
-                out,
-            );
+            self.extract_range_distinct_rec(level + 1, child_start, child_end, child_prefix, out);
         }
     }
 }
 
 impl<'a, T, const B_SIZE: usize> AccessUnsigned for QwtView<'a, T, B_SIZE>
-
 where
     T: WTIndexable,
     usize: AsPrimitive<T>,
@@ -576,7 +626,16 @@ where
         let decode_n_buckets = get_u16(bytes, &mut o) as usize;
         let _ = o;
 
-        let dir_end = HEADER_SIZE + n_levels * HQWT_LEVEL_DIR_SIZE;
+        if n_levels > MAX_QUAD_LEVELS || (n > 0 && n_levels == 0) {
+            return Err(LayoutError::Inconsistent {
+                detail: "Huffman QWT level count is invalid",
+            });
+        }
+
+        let dir_end = n_levels
+            .checked_mul(HQWT_LEVEL_DIR_SIZE)
+            .and_then(|size| HEADER_SIZE.checked_add(size))
+            .ok_or(LayoutError::Truncated)?;
         if bytes.len() < dir_end {
             return Err(LayoutError::Truncated);
         }
@@ -605,7 +664,13 @@ where
                 p += 4;
                 let sym_u = u64::from_le_bytes(bytes[p..p + 8].try_into().unwrap()) as usize;
                 p += 8;
-                bucket.push((content, sym_u.as_()));
+                let symbol: T = sym_u.as_();
+                if symbol.as_() != sym_u {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "Huffman decode symbol does not fit the requested type",
+                    });
+                }
+                bucket.push((content, symbol));
             }
             codes_decode.push(bucket);
         }
@@ -617,6 +682,180 @@ where
             let dir = HqwtLevelDir::read(&bytes[dir_off..dir_off + HQWT_LEVEL_DIR_SIZE])?;
             levels.push(RSQVectorView::from_dir(bytes, &dir.plain)?);
             lens.push(dir.level_len as usize);
+        }
+
+        if n > 0 && lens.first().copied() != Some(n) {
+            return Err(LayoutError::Inconsistent {
+                detail: "first Huffman QWT level length disagrees with header length",
+            });
+        }
+        if levels
+            .iter()
+            .zip(&lens)
+            .any(|(level, &len)| level.len() != len)
+        {
+            return Err(LayoutError::Inconsistent {
+                detail: "Huffman QWT level payload length disagrees with directory",
+            });
+        }
+        let max_code_bits = n_levels.saturating_mul(2);
+        for (symbol, code) in codes_encode.iter().enumerate() {
+            if code.len == 0 {
+                continue;
+            }
+            let code_len = code.len as usize;
+            if !code_len.is_multiple_of(2)
+                || code_len > max_code_bits
+                || code_len > u32::BITS as usize
+            {
+                return Err(LayoutError::Inconsistent {
+                    detail: "Huffman encode code length is invalid",
+                });
+            }
+            if code_len < u32::BITS as usize && code.content >= (1u32 << code_len) {
+                return Err(LayoutError::Inconsistent {
+                    detail: "Huffman encode code has bits outside its declared length",
+                });
+            }
+            let Some(bucket) = codes_decode.get(code_len) else {
+                return Err(LayoutError::Inconsistent {
+                    detail: "Huffman decode bucket is missing",
+                });
+            };
+            let Ok(index) = bucket.binary_search_by_key(&code.content, |(content, _)| *content)
+            else {
+                return Err(LayoutError::Inconsistent {
+                    detail: "Huffman encode code is absent from its decode bucket",
+                });
+            };
+            if bucket[index].1.as_() != symbol {
+                return Err(LayoutError::Inconsistent {
+                    detail: "Huffman encode/decode symbol mapping disagrees",
+                });
+            }
+        }
+        for (code_len, bucket) in codes_decode.iter().enumerate() {
+            if bucket.windows(2).any(|pair| pair[0].0 >= pair[1].0) {
+                return Err(LayoutError::Inconsistent {
+                    detail: "Huffman decode bucket must be strictly sorted",
+                });
+            }
+            for &(content, symbol) in bucket {
+                let symbol_index: usize = symbol.as_();
+                let Some(code) = codes_encode.get(symbol_index) else {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "Huffman decode symbol is outside the encode table",
+                    });
+                };
+                if code.len as usize != code_len || code.content != content {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "Huffman decode entry disagrees with its encode code",
+                    });
+                }
+            }
+        }
+
+        // Validate every code's rank path at the full sequence boundary. All
+        // smaller query positions remain within the same checked intervals.
+        for code in codes_encode.iter().filter(|code| code.len != 0) {
+            let mut start = 0usize;
+            let mut end = n;
+            let mut shift = code.len as usize;
+            let mut level = 0usize;
+            while shift > 0 {
+                shift -= 2;
+                let Some(view) = levels.get(level) else {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "Huffman code descends beyond available levels",
+                    });
+                };
+                if end > view.len() {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "Huffman rank path exceeds a level length",
+                    });
+                }
+                let symbol = ((code.content >> shift) & 3) as u8;
+                let offsets = view.n_occs_smaller();
+                start = view.rank(symbol, start).ok_or(LayoutError::Inconsistent {
+                    detail: "Huffman rank path start is invalid",
+                })? + offsets[symbol as usize];
+                end = view.rank(symbol, end).ok_or(LayoutError::Inconsistent {
+                    detail: "Huffman rank path end is invalid",
+                })? + offsets[symbol as usize];
+                level += 1;
+            }
+        }
+
+        // Validate all populated access paths as contiguous wavelet ranges.
+        // This proves the same property as decoding every row, but work scales
+        // with the Huffman prefix tree rather than the number of stored rows.
+        let mut pending = if n == 0 {
+            Vec::new()
+        } else {
+            vec![(0usize, 0usize, n, 0u32, 0usize)]
+        };
+        while let Some((level_index, start, end, content, code_len)) = pending.pop() {
+            let Some(level) = levels.get(level_index) else {
+                return Err(LayoutError::Inconsistent {
+                    detail: "Huffman access path exceeds available levels",
+                });
+            };
+            if end > lens[level_index] {
+                return Err(LayoutError::Inconsistent {
+                    detail: "Huffman access path exceeds a level",
+                });
+            }
+            // SAFETY: `start..end` was checked against this level's length;
+            // child ranges come from validated rank metadata and offsets.
+            let ranks_start = unsafe { level.rank_all_unchecked(start) };
+            let ranks_end = unsafe { level.rank_all_unchecked(end) };
+            for digit in 0..4usize {
+                if ranks_start[digit] == ranks_end[digit] {
+                    continue;
+                }
+                let child_content = (content << 2) | digit as u32;
+                let child_code_len = code_len + 2;
+                let has_decode = codes_decode.get(child_code_len).is_some_and(|bucket| {
+                    bucket
+                        .binary_search_by_key(&child_content, |(candidate, _)| *candidate)
+                        .is_ok()
+                });
+                let Some(next_level_len) = lens.get(level_index + 1).copied() else {
+                    if !has_decode {
+                        return Err(LayoutError::Inconsistent {
+                            detail: "Huffman access path has no decode entry",
+                        });
+                    }
+                    continue;
+                };
+                let offset = level.n_occs_smaller()[digit];
+                let child_start = offset + ranks_start[digit];
+                let child_end = offset + ranks_end[digit];
+                if child_end <= next_level_len {
+                    if has_decode {
+                        return Err(LayoutError::Inconsistent {
+                            detail: "Huffman decode entry has a populated descendant",
+                        });
+                    }
+                    pending.push((
+                        level_index + 1,
+                        child_start,
+                        child_end,
+                        child_content,
+                        child_code_len,
+                    ));
+                } else if child_start >= next_level_len {
+                    if !has_decode {
+                        return Err(LayoutError::Inconsistent {
+                            detail: "Huffman access path has no decode entry",
+                        });
+                    }
+                } else {
+                    return Err(LayoutError::Inconsistent {
+                        detail: "Huffman prefix is split across terminal and continuing rows",
+                    });
+                }
+            }
         }
 
         Ok(Self {
@@ -915,6 +1154,16 @@ mod tests {
     }
 
     #[test]
+    fn qwt_view_rejects_sigma_that_disagrees_with_payload() {
+        let original = QWT256::from(vec![1u32, 2, 3]);
+        let mut bytes = qwt256_to_bytes(&original).unwrap();
+        bytes[16..24].copy_from_slice(&2u64.to_le_bytes());
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let error = QwtView::<u32, 256>::from_bytes(aligned.as_slice()).unwrap_err();
+        assert!(matches!(error, LayoutError::Inconsistent { .. }));
+    }
+
+    #[test]
     fn qwt_view_rejects_unaligned_base() {
         // Build a blob, then force the slice start to be 1-mod-64 so cast fails
         // when there is at least one level with POD payload.
@@ -968,6 +1217,28 @@ mod tests {
         assert!(matches!(error, LayoutError::Inconsistent { .. }));
     }
 
+    #[test]
+    fn qwt_view_rejects_in_range_but_false_rank_metadata() {
+        let original = QWT256::from(vec![0u32; 5_000]);
+        let mut bytes = qwt256_to_bytes(&original).unwrap();
+        let sb_field = HEADER_SIZE + 24;
+        let sb_offset =
+            u64::from_le_bytes(bytes[sb_field..sb_field + 8].try_into().unwrap()) as usize;
+        let second_counter = sb_offset + std::mem::size_of::<crate::SuperblockPlain>();
+        let mut packed = u128::from_le_bytes(
+            bytes[second_counter..second_counter + 16]
+                .try_into()
+                .unwrap(),
+        );
+        assert!(packed >> 84 > 0);
+        packed -= 1u128 << 84;
+        bytes[second_counter..second_counter + 16].copy_from_slice(&packed.to_le_bytes());
+
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let error = QwtView::<u32, 256>::from_bytes(aligned.as_slice()).unwrap_err();
+        assert!(matches!(error, LayoutError::Inconsistent { .. }));
+    }
+
     /// Multi-superblock image where a rare symbol first appears late.
     #[test]
     fn qwt_view_accepts_late_debuting_symbol() {
@@ -1004,15 +1275,22 @@ mod tests {
         let data: Vec<u32> = (0..50_000).map(|x| (x % 4) as u32).collect();
         let original = QWT256::from(data);
         let mut bytes = qwt256_to_bytes(&original).unwrap();
-        let n_sel0 =
-            u32::from_le_bytes(bytes[HEADER_SIZE + 72..HEADER_SIZE + 76].try_into().unwrap())
-                as usize;
+        let n_sel0 = u32::from_le_bytes(
+            bytes[HEADER_SIZE + 72..HEADER_SIZE + 76]
+                .try_into()
+                .unwrap(),
+        ) as usize;
         assert!(n_sel0 >= 2);
-        let off_sel0 =
-            u64::from_le_bytes(bytes[HEADER_SIZE + 40..HEADER_SIZE + 48].try_into().unwrap())
-                as usize;
-        let n_sb =
-            u32::from_le_bytes(bytes[HEADER_SIZE + 32..HEADER_SIZE + 36].try_into().unwrap());
+        let off_sel0 = u64::from_le_bytes(
+            bytes[HEADER_SIZE + 40..HEADER_SIZE + 48]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let n_sb = u32::from_le_bytes(
+            bytes[HEADER_SIZE + 32..HEADER_SIZE + 36]
+                .try_into()
+                .unwrap(),
+        );
         assert!(n_sb > 1);
         let last = n_sb - 1;
         bytes[off_sel0..off_sel0 + 4].copy_from_slice(&last.to_le_bytes());
@@ -1021,10 +1299,8 @@ mod tests {
         assert!(matches!(error, LayoutError::Inconsistent { .. }));
     }
 
-
     #[test]
     fn hqwt_view_matches_owned() {
-
         let data: Vec<u32> = (0..500).map(|x| (x * 7) % 64).collect();
         let original = HQWT256::from(data.clone());
         let bytes = hqwt256_to_bytes(&original).unwrap();
@@ -1051,6 +1327,30 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn hqwt_view_rejects_code_longer_than_available_levels() {
+        let original = HQWT256::from(vec![0u32, 1, 0, 1, 0, 1]);
+        let mut bytes = hqwt256_to_bytes(&original).unwrap();
+        let n_levels = u16::from_le_bytes(bytes[16..18].try_into().unwrap()) as usize;
+        let encode_len = u16::from_le_bytes(bytes[18..20].try_into().unwrap()) as usize;
+        let encode_offset = align_up(HEADER_SIZE + n_levels * HQWT_LEVEL_DIR_SIZE, 8);
+        let mut changed = false;
+        for index in 0..encode_len {
+            let len_offset = encode_offset + index * 8 + 4;
+            let len = u32::from_le_bytes(bytes[len_offset..len_offset + 4].try_into().unwrap());
+            if len != 0 {
+                bytes[len_offset..len_offset + 4].copy_from_slice(&34u32.to_le_bytes());
+                changed = true;
+                break;
+            }
+        }
+        assert!(changed);
+
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let error = HqwtView::<u32, 256>::from_bytes(aligned.as_slice()).unwrap_err();
+        assert!(matches!(error, LayoutError::Inconsistent { .. }));
     }
 
     #[test]
@@ -1200,5 +1500,4 @@ mod tests {
             );
         }
     }
-
 }

--- a/src/bytes/view.rs
+++ b/src/bytes/view.rs
@@ -968,8 +968,63 @@ mod tests {
         assert!(matches!(error, LayoutError::Inconsistent { .. }));
     }
 
+    /// Multi-superblock image where a rare symbol first appears late.
+    #[test]
+    fn qwt_view_accepts_late_debuting_symbol() {
+        let mut data = vec![1u32; 100_000];
+        data.push(7);
+        let original = QWT256::from(data.clone());
+        let bytes = qwt256_to_bytes(&original).unwrap();
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let view: QwtView<'_, u32, 256> = QwtView::from_bytes(aligned.as_slice()).unwrap();
+
+        assert_eq!(view.len(), original.len());
+        for i in (0..data.len()).step_by(997) {
+            assert_eq!(view.get(i), original.get(i), "get@{i}");
+        }
+        for &sym in &[1u32, 7] {
+            for i in (0..=data.len()).step_by(4099) {
+                assert_eq!(view.rank(sym, i), original.rank(sym, i), "rank({sym},{i})");
+            }
+            if let Some(cnt) = original.rank(sym, data.len()) {
+                for k in 0..cnt.min(5) {
+                    assert_eq!(
+                        view.select(sym, k),
+                        original.select(sym, k),
+                        "select({sym},{k})"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Select sample pointing at the wrong superblock is rejected.
+    #[test]
+    fn qwt_view_rejects_corrupt_select_sample() {
+        let data: Vec<u32> = (0..50_000).map(|x| (x % 4) as u32).collect();
+        let original = QWT256::from(data);
+        let mut bytes = qwt256_to_bytes(&original).unwrap();
+        let n_sel0 =
+            u32::from_le_bytes(bytes[HEADER_SIZE + 72..HEADER_SIZE + 76].try_into().unwrap())
+                as usize;
+        assert!(n_sel0 >= 2);
+        let off_sel0 =
+            u64::from_le_bytes(bytes[HEADER_SIZE + 40..HEADER_SIZE + 48].try_into().unwrap())
+                as usize;
+        let n_sb =
+            u32::from_le_bytes(bytes[HEADER_SIZE + 32..HEADER_SIZE + 36].try_into().unwrap());
+        assert!(n_sb > 1);
+        let last = n_sb - 1;
+        bytes[off_sel0..off_sel0 + 4].copy_from_slice(&last.to_le_bytes());
+        let aligned = AlignedBytes::from_slice(&bytes);
+        let error = QwtView::<u32, 256>::from_bytes(aligned.as_slice()).unwrap_err();
+        assert!(matches!(error, LayoutError::Inconsistent { .. }));
+    }
+
+
     #[test]
     fn hqwt_view_matches_owned() {
+
         let data: Vec<u32> = (0..500).map(|x| (x * 7) % 64).collect();
         let original = HQWT256::from(data.clone());
         let bytes = hqwt256_to_bytes(&original).unwrap();

--- a/src/darray/mod.rs
+++ b/src/darray/mod.rs
@@ -19,8 +19,7 @@
 //! Without this support, the query [`SelectBin::select0`] will panic.
 //!
 //! ```
-//! use qwt::DArray;
-//! use qwt::{SelectBin, RankBin};
+//! use qwt::{DArray, RankBin, SelectBin};
 //!
 //! let vv: Vec<usize> = vec![0, 12, 33, 42, 55, 61, 1000];
 //! let da: DArray<false> = vv.into_iter().collect();
@@ -53,18 +52,14 @@
 //! the position of the first one in its block and start a linear scan from that position
 //! looking for the i-th occurrence of 1. If the block is sparse, the answer is stored in vector
 //! *overflow_positions*.
-//!
 // TODO! //! Space overhead is TODO!
-//!
 //! These three vectors are stored in a private struct `Inventories`.
 //! The const generic BITS in this struct allows us to build and store these vectors to support
 //! `select0` as well.
 
 use crate::bitvector::{BitVectorBitPositionsIter, BitVectorIter};
 use crate::utils::select_in_word;
-use crate::BitVector;
-use crate::{AccessBin, SelectBin};
-
+use crate::{AccessBin, BitVector, SelectBin};
 use mem_dbg::{MemDbg, MemSize};
 use serde::{Deserialize, Serialize};
 #[cfg(target_arch = "x86_64")]
@@ -191,8 +186,8 @@ impl<const SELECT0_SUPPORT: bool> DArray<SELECT0_SUPPORT> {
     /// ```
     /// use qwt::{DArray, SelectBin};
     ///
-    /// let v = vec![0,2,3,4,5];
-    /// let da: DArray::<true> = v.into_iter().collect(); // <true> to support the select0 query
+    /// let v = vec![0, 2, 3, 4, 5];
+    /// let da: DArray<true> = v.into_iter().collect(); // <true> to support the select0 query
     ///
     /// assert_eq!(da.select1(2), Some(3));
     /// assert_eq!(da.select0(0), Some(1));
@@ -254,8 +249,8 @@ impl<const SELECT0_SUPPORT: bool> DArray<SELECT0_SUPPORT> {
     /// # Examples
     ///
     /// ```
-    /// use qwt::DArray;
     /// use qwt::perf_and_test_utils::negate_vector;
+    /// use qwt::DArray;
     ///
     /// let vv: Vec<usize> = vec![0, 63, 128, 129, 254, 1026];
     /// let da: DArray = vv.iter().copied().collect();
@@ -281,7 +276,7 @@ impl<const SELECT0_SUPPORT: bool> DArray<SELECT0_SUPPORT> {
     /// ```
     /// use qwt::DArray;
     ///
-    /// let v = vec![0,2,3,5];
+    /// let v = vec![0, 2, 3, 5];
     /// let da: DArray = v.into_iter().collect();
     ///
     /// let mut iter = da.iter();
@@ -429,10 +424,10 @@ impl<const SELECT0_SUPPORT: bool> AccessBin for DArray<SELECT0_SUPPORT> {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{DArray, AccessBin};
+    /// use qwt::{AccessBin, DArray};
     ///
-    /// let v = vec![0,2,3,4,5];
-    /// let da: DArray = v.into_iter().collect();;
+    /// let v = vec![0, 2, 3, 4, 5];
+    /// let da: DArray = v.into_iter().collect();
     ///
     /// assert_eq!(da.get(5), Some(true));
     /// assert_eq!(da.get(1), Some(false));
@@ -451,11 +446,11 @@ impl<const SELECT0_SUPPORT: bool> AccessBin for DArray<SELECT0_SUPPORT> {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{DArray, AccessBin};
+    /// use qwt::{AccessBin, DArray};
     ///
-    /// let v = vec![0,2,3,4,5];
-    /// let da: DArray = v.into_iter().collect();;
-    /// assert_eq!(unsafe{da.get_unchecked(8)}, false);
+    /// let v = vec![0, 2, 3, 4, 5];
+    /// let da: DArray = v.into_iter().collect();
+    /// assert_eq!(unsafe { da.get_unchecked(8) }, false);
     /// ```
 
     #[inline(always)]
@@ -500,7 +495,7 @@ impl<const SELECT0_SUPPORT: bool> SelectBin for DArray<SELECT0_SUPPORT> {
     /// let v: Vec<usize> = vec![0, 12, 33, 42, 55, 61, 1000];
     /// let da: DArray = v.into_iter().collect();
     ///
-    /// assert_eq!(unsafe{da.select1_unchecked(1)}, 12);
+    /// assert_eq!(unsafe { da.select1_unchecked(1) }, 12);
     /// ```
 
     #[inline(always)]
@@ -546,8 +541,8 @@ impl<const SELECT0_SUPPORT: bool> SelectBin for DArray<SELECT0_SUPPORT> {
     /// let v: Vec<usize> = vec![0, 12, 33, 42, 55, 61, 1000];
     /// let da: DArray<true> = v.into_iter().collect();
     ///
-    /// assert_eq!(unsafe{da.select0_unchecked(1)}, 2);
-    /// assert_eq!(unsafe{da.select0_unchecked(11)}, 13);
+    /// assert_eq!(unsafe { da.select0_unchecked(1) }, 2);
+    /// assert_eq!(unsafe { da.select0_unchecked(11) }, 13);
     /// ```
     #[inline(always)]
     unsafe fn select0_unchecked(&self, i: usize) -> usize {

--- a/src/darray/mod.rs
+++ b/src/darray/mod.rs
@@ -56,7 +56,6 @@
 //! These three vectors are stored in a private struct `Inventories`.
 //! The const generic BITS in this struct allows us to build and store these vectors to support
 //! `select0` as well.
-
 use crate::bitvector::{BitVectorBitPositionsIter, BitVectorIter};
 use crate::utils::select_in_word;
 use crate::{AccessBin, BitVector, SelectBin};
@@ -72,7 +71,6 @@ const MAX_IN_BLOCK_DISTACE: usize = 1 << 16;
 /// Const generic SELECT0_SUPPORT may optionally add
 /// extra data structures to support fast `select0` queries,
 /// which otherwise are not supported.
-
 #[derive(Default, Debug, Clone, Serialize, Deserialize, MemSize, MemDbg, PartialEq)]
 pub struct DArray<const SELECT0_SUPPORT: bool = false> {
     bv: BitVector,
@@ -386,9 +384,9 @@ impl<const SELECT0_SUPPORT: bool> DArray<SELECT0_SUPPORT> {
         let mut word_idx = start_pos >> 6;
         let word_shift = start_pos & 63;
         let mut word = if !BIT {
-            !self.bv.get_word(word_idx) & (std::u64::MAX << word_shift) // if select0, negate the current word!
+            !self.bv.get_word(word_idx) & (u64::MAX << word_shift) // if select0, negate the current word!
         } else {
-            self.bv.get_word(word_idx) & (std::u64::MAX << word_shift)
+            self.bv.get_word(word_idx) & (u64::MAX << word_shift)
         };
 
         loop {
@@ -433,7 +431,6 @@ impl<const SELECT0_SUPPORT: bool> AccessBin for DArray<SELECT0_SUPPORT> {
     /// assert_eq!(da.get(1), Some(false));
     /// assert_eq!(da.get(10), None);
     /// ```
-
     #[inline(always)]
     fn get(&self, i: usize) -> Option<bool> {
         self.bv.get(i)
@@ -452,7 +449,6 @@ impl<const SELECT0_SUPPORT: bool> AccessBin for DArray<SELECT0_SUPPORT> {
     /// let da: DArray = v.into_iter().collect();
     /// assert_eq!(unsafe { da.get_unchecked(8) }, false);
     /// ```
-
     #[inline(always)]
     unsafe fn get_unchecked(&self, i: usize) -> bool {
         self.bv.get_unchecked(i)
@@ -477,7 +473,6 @@ impl<const SELECT0_SUPPORT: bool> SelectBin for DArray<SELECT0_SUPPORT> {
     ///
     /// # Panics
     /// It panics if [`DArray`] is built without support for `select0`query.
-
     #[inline(always)]
     fn select1(&self, i: usize) -> Option<usize> {
         self.select(i, &self.ones_inventories)
@@ -497,7 +492,6 @@ impl<const SELECT0_SUPPORT: bool> SelectBin for DArray<SELECT0_SUPPORT> {
     ///
     /// assert_eq!(unsafe { da.select1_unchecked(1) }, 12);
     /// ```
-
     #[inline(always)]
     unsafe fn select1_unchecked(&self, i: usize) -> usize {
         self.select(i, &self.ones_inventories).unwrap()
@@ -521,7 +515,6 @@ impl<const SELECT0_SUPPORT: bool> SelectBin for DArray<SELECT0_SUPPORT> {
     ///
     /// # Panics
     /// It panics if [`DArray`] is built without support for `select0`query.
-
     #[inline(always)]
     fn select0(&self, i: usize) -> Option<usize> {
         assert!(SELECT0_SUPPORT);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,11 @@ pub use bitvector::{narrow, wide, BitVector, BitVectorMut};
 
 pub mod utils;
 
+pub mod bytes;
+pub use bytes::LayoutError;
+
 pub use qvector::rs_qvector::{RSQVector, RSQVector256, RSQVector512};
+
 
 pub mod quadwt;
 pub use quadwt::huffqwt::{HuffQWaveletTree, PrefixCode};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,36 +4,26 @@ pub use mem_dbg;
 
 pub mod perf_and_test_utils;
 pub mod qvector;
-use std::{
-    marker::PhantomData,
-    ops::{Range, RangeBounds},
-};
-
 use num_traits::AsPrimitive;
-pub use qvector::QVector;
-pub use qvector::QVectorBuilder;
+pub use qvector::rs_qvector::SuperblockPlain;
+pub use qvector::{DataLine, QVector, QVectorBuilder};
+use std::marker::PhantomData;
+use std::ops::{Range, RangeBounds};
 
 pub mod bitvector;
-pub use bitvector::narrow;
-pub use bitvector::wide;
-pub use bitvector::BitVector;
-pub use bitvector::BitVectorMut;
-
 #[deprecated(since = "0.5.0", note = "renamed to `qwt::narrow::RS`")]
 pub use bitvector::narrow::RS as RSNarrow;
 #[deprecated(since = "0.5.0", note = "renamed to `qwt::wide::RS`")]
 pub use bitvector::wide::RS as RSWide;
+pub use bitvector::{narrow, wide, BitVector, BitVectorMut};
 
 pub mod utils;
 
-pub use qvector::rs_qvector::RSQVector;
-pub use qvector::rs_qvector::RSQVector256;
-pub use qvector::rs_qvector::RSQVector512;
+pub use qvector::rs_qvector::{RSQVector, RSQVector256, RSQVector512};
 
 pub mod quadwt;
-pub use quadwt::huffqwt::HuffQWaveletTree;
-pub use quadwt::QWaveletTree;
-pub use quadwt::WTIndexable;
+pub use quadwt::huffqwt::{HuffQWaveletTree, PrefixCode};
+pub use quadwt::{QWaveletTree, RangeDistinctIter, WTIndexable};
 
 pub mod binwt;
 pub use binwt::WaveletTree;
@@ -235,6 +225,21 @@ pub trait RankQuad {
     /// Calling this method with an out-of-bounds index or with a symbol larger than
     /// 3 is undefined behavior.
     unsafe fn rank_unchecked(&self, symbol: u8, i: usize) -> usize;
+
+    /// Ranks of all four symbols `0..3` up to position `i` (excluded).
+    /// Default: four independent `rank_unchecked` calls.
+    ///
+    /// # Safety
+    /// Calling this method with an out-of-bounds index is undefined behavior.
+    #[inline(always)]
+    unsafe fn rank_all_unchecked(&self, i: usize) -> [usize; 4] {
+        [
+            self.rank_unchecked(0, i),
+            self.rank_unchecked(1, i),
+            self.rank_unchecked(2, i),
+            self.rank_unchecked(3, i),
+        ]
+    }
 }
 
 /// A trait for the support of `select` query over the alphabet [0..3].
@@ -256,7 +261,7 @@ pub trait SelectQuad {
 /// to provide to be used in a Quad Wavelet Tree.
 pub trait WTSupport: AccessQuad + RankQuad + SelectQuad {
     /// Returns the number of occurrences of `symbol` in the indexed sequence,
-    /// `None` if `symbol` is larger than 3, i.e., `symbol` is not valid.  
+    /// `None` if `symbol` is larger than 3, i.e., `symbol` is not valid.
     fn occs(&self, symbol: u8) -> Option<usize>;
 
     /// Returns the number of occurrences of `symbol` in the indexed sequence.
@@ -268,7 +273,7 @@ pub trait WTSupport: AccessQuad + RankQuad + SelectQuad {
 
     /// Returns the number of occurrences of all the symbols smaller than the
     /// input `symbol`, `None` if `symbol` is larger than 3,
-    /// i.e., `symbol` is not valid.  
+    /// i.e., `symbol` is not valid.
     fn occs_smaller(&self, symbol: u8) -> Option<usize>;
 
     /// Returns the rank of `symbol` up to the block that contains the position

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ pub use bytes::LayoutError;
 
 pub use qvector::rs_qvector::{RSQVector, RSQVector256, RSQVector512};
 
-
 pub mod quadwt;
 pub use quadwt::huffqwt::{HuffQWaveletTree, PrefixCode};
 pub use quadwt::{QWaveletTree, RangeDistinctIter, WTIndexable};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 
 pub use mem_dbg;
 
+pub(crate) const MAX_QUAD_LEVELS: usize = u128::BITS as usize / 2;
+
 pub mod perf_and_test_utils;
 pub mod qvector;
 use num_traits::AsPrimitive;

--- a/src/perf_and_test_utils/mod.rs
+++ b/src/perf_and_test_utils/mod.rs
@@ -110,36 +110,34 @@ pub fn gen_strictly_increasing_sequence(n: usize, u: usize) -> Vec<usize> {
     v
 }
 
-/*
-/// Tests rank1 op by querying every position of a bit set to 1 in the binary vector
-/// and the next position.
-pub fn test_rank1<T>(ds: &T, bv: &BitVector)
-where
-    T: Rank,
-{
-    for (rank, pos) in bv.ones().enumerate() {
-        let result = ds.rank1(pos);
-        assert_eq!(result, Some(rank));
-        let result = ds.rank1(pos + 1);
-        dbg!(pos + 1, rank);
-        assert_eq!(result, Some(rank + 1));
-    }
-    let result = ds.rank1(bv.len() + 1);
-    assert_eq!(result, None);
-}
-
-/// Tests select1 op by querying every position of vector.
-pub fn test_select1<T>(ds: &T, data: &[usize])
-where
-    T: Select,
-{
-    for (i, &v) in data.iter().enumerate() {
-        let result = ds.select1(i);
-        dbg!(i, v);
-        assert_eq!(result, Some(v));
-    }
-}
-*/
+// Tests rank1 op by querying every position of a bit set to 1 in the binary vector
+// and the next position.
+// pub fn test_rank1<T>(ds: &T, bv: &BitVector)
+// where
+// T: Rank,
+// {
+// for (rank, pos) in bv.ones().enumerate() {
+// let result = ds.rank1(pos);
+// assert_eq!(result, Some(rank));
+// let result = ds.rank1(pos + 1);
+// dbg!(pos + 1, rank);
+// assert_eq!(result, Some(rank + 1));
+// }
+// let result = ds.rank1(bv.len() + 1);
+// assert_eq!(result, None);
+// }
+//
+// Tests select1 op by querying every position of vector.
+// pub fn test_select1<T>(ds: &T, data: &[usize])
+// where
+// T: Select,
+// {
+// for (i, &v) in data.iter().enumerate() {
+// let result = ds.select1(i);
+// dbg!(i, v);
+// assert_eq!(result, Some(v));
+// }
+// }
 
 pub struct TimingQueries {
     timings: Vec<u128>,

--- a/src/quadwt/huffqwt.rs
+++ b/src/quadwt/huffqwt.rs
@@ -314,6 +314,39 @@ where
         &self.codes_decode
     }
 
+    /// Assemble a Huffman QWT from prebuilt levels and code tables.
+    ///
+    /// Inverse of the inspector accessors. Used by zero-copy I/O.
+    /// Prefetch-augmented trees are rejected in v1.
+    pub fn from_parts(
+        n: usize,
+        n_levels: usize,
+        codes_encode: Vec<PrefixCode>,
+        codes_decode: Vec<Vec<(u32, T)>>,
+        qvs: Vec<RS>,
+        lens: Vec<usize>,
+    ) -> Result<Self, crate::bytes::LayoutError> {
+        if WITH_PREFETCH_SUPPORT {
+            return Err(crate::bytes::LayoutError::PrefetchNotSupported);
+        }
+        if qvs.len() != n_levels || lens.len() != n_levels {
+            return Err(crate::bytes::LayoutError::Inconsistent {
+                detail: "n_levels disagrees with qvs/lens lengths",
+            });
+        }
+        Ok(Self {
+            n,
+            n_levels,
+            codes_encode,
+            codes_decode,
+            qvs,
+            lens,
+            prefetch_support: None,
+            phantom_data: PhantomData,
+        })
+    }
+
+
     /// Returns an iterator over the values in the wavelet tree.
     ///
     /// # Examples

--- a/src/quadwt/huffqwt.rs
+++ b/src/quadwt/huffqwt.rs
@@ -672,7 +672,6 @@ where
     /// assert_eq!(qwt.get(3), Some(0));
     /// assert_eq!(qwt.get(8), None);
     /// ```
-
     #[inline(always)]
     fn get(&self, i: usize) -> Option<Self::Item> {
         if i >= self.n {
@@ -703,7 +702,6 @@ where
     ///     assert_eq!(qwt.get_unchecked(3), 0);
     /// }
     /// ```
-
     #[inline(always)]
     unsafe fn get_unchecked(&self, i: usize) -> Self::Item {
         let mut cur_i = i;
@@ -907,7 +905,6 @@ where
     /// assert_eq!(qwt.rank(1, 0), Some(0));
     /// assert_eq!(qwt.rank(1, 9), None); // Too large position
     /// ```
-
     #[inline(always)]
     fn rank(&self, symbol: Self::Item, i: usize) -> Option<usize> {
         if i > self.n
@@ -944,7 +941,6 @@ where
     ///     assert_eq!(qwt.rank_unchecked(1, 2), 1);
     /// }
     /// ```
-
     #[inline(always)]
     unsafe fn rank_unchecked(&self, symbol: Self::Item, i: usize) -> usize {
         let mut cur_i = i;
@@ -997,7 +993,6 @@ where
     /// assert_eq!(qwt.select(5, 0), Some(6));
     /// assert_eq!(qwt.select(6, 1), None);
     /// ```
-
     #[inline(always)]
     fn select(&self, symbol: Self::Item, i: usize) -> Option<usize> {
         if symbol.as_() >= self.codes_encode.len() || self.codes_encode[symbol.as_()].len == 0 {
@@ -1051,7 +1046,6 @@ where
     ///
     /// In the current implementation, there is no efficiency reason to prefer this
     /// unsafe `select` over the safe one.
-
     #[inline(always)]
     unsafe fn select_unchecked(&self, symbol: Self::Item, i: usize) -> usize {
         self.select(symbol, i).unwrap()

--- a/src/quadwt/huffqwt.rs
+++ b/src/quadwt/huffqwt.rs
@@ -1,22 +1,19 @@
-use std::{
-    collections::HashMap,
-    fmt::Debug,
-    marker::PhantomData,
-    ops::{Bound, Range, RangeBounds},
-    vec,
+use super::prefetch_support::PrefetchSupport;
+use super::RSforWT;
+use crate::utils::stable_partition_of_4_with_codes;
+use crate::{
+    AccessUnsigned, OccsRangeUnsigned, QVectorBuilder, RankUnsigned, SelectUnsigned, WTIndexable,
+    WTIterator,
 };
-
 use mem_dbg::{MemDbg, MemSize};
 use minimum_redundancy::{BitsPerFragment, Coding};
 use num_traits::AsPrimitive;
 use serde::{Deserialize, Serialize};
-
-use crate::{
-    utils::stable_partition_of_4_with_codes, AccessUnsigned, OccsRangeUnsigned, QVectorBuilder,
-    RankUnsigned, SelectUnsigned, WTIndexable, WTIterator,
-};
-
-use super::{prefetch_support::PrefetchSupport, RSforWT};
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::ops::{Bound, Range, RangeBounds};
+use std::vec;
 
 #[derive(Default, Clone, PartialEq, Serialize, Deserialize, MemDbg, MemSize, Debug)]
 pub struct PrefixCode {
@@ -38,7 +35,7 @@ pub struct HuffQWaveletTree<T, RS, const WITH_PREFETCH_SUPPORT: bool = false> {
     prefetch_support: Option<Vec<PrefetchSupport>>,
 }
 
-struct LenInfo(usize, u32); //symbol, len
+struct LenInfo(usize, u32); // symbol, len
 
 #[allow(clippy::identity_op)]
 fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCode> {
@@ -54,7 +51,7 @@ fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCod
 
     let mut c = vec![0; alph_size * 4];
     let mut assignments = vec![PrefixCode { content: 0, len: 0 }; sigma + 1];
-    let mut m = 1; //how many codes we have so far
+    let mut m = 1; // how many codes we have so far
     let mut l = 0;
 
     for j in 0..alph_size {
@@ -71,8 +68,8 @@ fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCod
             l += 2;
         }
 
-        //the codes are stored in lexicographic order of their reverse codes,
-        //now we get the actual one we need by reversing it
+        // the codes are stored in lexicographic order of their reverse codes,
+        // now we get the actual one we need by reversing it
         let mut reversed_code = 0;
         for t in (0..l).step_by(2) {
             reversed_code |= ((c[j] >> t) & 3) << (l - t - 2);
@@ -128,7 +125,7 @@ where
         }
 
         let sigma = *sequence.iter().max().unwrap();
-        //count symbol frequences
+        // count symbol frequences
         let freqs = sequence.iter().fold(HashMap::new(), |mut map, &c| {
             *map.entry(c.as_()).or_insert(0usize) += 1;
             map
@@ -164,7 +161,7 @@ where
             .map(|x| x.len)
             .max()
             .expect("error while finding max code length") as usize;
-        let n_levels = max_len / 2; //we handle 2 bits for each level
+        let n_levels = max_len / 2; // we handle 2 bits for each level
 
         let mut codes_decode = vec![Vec::default(); max_len + 1];
         for (i, c) in codes.iter().enumerate() {
@@ -173,7 +170,7 @@ where
             }
         }
 
-        //sort codes to make it easier to search
+        // sort codes to make it easier to search
         for v in codes_decode.iter_mut() {
             v.sort_by_key(|(x, _)| *x)
         }
@@ -194,7 +191,7 @@ where
                     .expect("some error occurred during code translation while building huffqwt");
 
                 if cur_code.len >= shift {
-                    //we put in a qvector
+                    // we put in a qvector
                     let qv_symbol = (cur_code.content >> (cur_code.len - shift)) & 3;
                     cur_qv.push(qv_symbol as u8);
                 }
@@ -289,6 +286,34 @@ where
         self.n_levels
     }
 
+    /// Wavelet levels (RSQ vectors).
+    ///
+    /// Exposed for zero-copy / mmap flatten of the tree layout.
+    #[must_use]
+    pub fn levels(&self) -> &[RS] {
+        &self.qvs
+    }
+
+    /// Per-level sequence lengths (`lens[level]`), needed by Huffman `get`
+    /// early-leaf termination. Same order as [`Self::levels`].
+    #[must_use]
+    pub fn level_lens(&self) -> &[usize] {
+        &self.lens
+    }
+
+    /// Encode LUT: index = symbol id, value = prefix code (len==0 ⇒ absent).
+    #[must_use]
+    pub fn codes_encode(&self) -> &[PrefixCode] {
+        &self.codes_encode
+    }
+
+    /// Decode LUT: `codes_decode[bit_len]` is sorted by code content.
+    /// Symbols are stored as `T` in the heap tree; callers flatten as needed.
+    #[must_use]
+    pub fn codes_decode(&self) -> &[Vec<(u32, T)>] {
+        &self.codes_decode
+    }
+
     /// Returns an iterator over the values in the wavelet tree.
     ///
     /// # Examples
@@ -302,7 +327,10 @@ where
     ///
     /// assert_eq!(qwt.iter().collect::<Vec<_>>(), data);
     ///
-    /// assert_eq!(qwt.iter().rev().collect::<Vec<_>>(), data.into_iter().rev().collect::<Vec<_>>());
+    /// assert_eq!(
+    ///     qwt.iter().rev().collect::<Vec<_>>(),
+    ///     data.into_iter().rev().collect::<Vec<_>>()
+    /// );
     /// ```
     pub fn iter(
         &self,
@@ -423,7 +451,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{HQWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, HQWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -432,8 +460,8 @@ where
     /// assert_eq!(qwt.rank_prefetch(1, 2), Some(1));
     /// assert_eq!(qwt.rank_prefetch(3, 8), Some(1));
     /// assert_eq!(qwt.rank_prefetch(1, 0), Some(0));
-    /// assert_eq!(qwt.rank_prefetch(1, 9), None);  // Too large position
-    /// assert_eq!(qwt.rank_prefetch(6, 1), None);  // Too large symbol
+    /// assert_eq!(qwt.rank_prefetch(1, 9), None); // Too large position
+    /// assert_eq!(qwt.rank_prefetch(6, 1), None); // Too large symbol
     /// ```
     #[inline(always)]
     #[must_use]
@@ -462,7 +490,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use qwt::{HQWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, HQWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -475,7 +503,7 @@ where
     #[must_use]
     #[inline(always)]
     pub unsafe fn rank_prefetch_unchecked(&self, symbol: T, i: usize) -> usize {
-        //we get the code on which we rank
+        // we get the code on which we rank
         let code = &self.codes_encode[symbol.as_()];
 
         if WITH_PREFETCH_SUPPORT {
@@ -583,7 +611,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{HQWT256, AccessUnsigned};
+    /// use qwt::{AccessUnsigned, HQWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -613,7 +641,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use qwt::{HQWT256, AccessUnsigned};
+    /// use qwt::{AccessUnsigned, HQWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -649,7 +677,7 @@ where
 
         // println!("found result len:{}, repr:{}", shift, result);
 
-        //find the symbol
+        // find the symbol
         let idx = self.codes_decode[shift]
             .binary_search_by_key(&result, |(x, _)| *x)
             .expect("could not translate symbol");
@@ -816,17 +844,17 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{HQWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, HQWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
     /// let qwt = HQWT256::from(data);
     ///
-    /// assert_eq!(qwt.rank(6, 1), None);  // Too large symbol
+    /// assert_eq!(qwt.rank(6, 1), None); // Too large symbol
     /// assert_eq!(qwt.rank(1, 2), Some(1));
     /// assert_eq!(qwt.rank(3, 8), Some(1));
     /// assert_eq!(qwt.rank(1, 0), Some(0));
-    /// assert_eq!(qwt.rank(1, 9), None);  // Too large position
+    /// assert_eq!(qwt.rank(1, 9), None); // Too large position
     /// ```
 
     #[inline(always)]
@@ -855,7 +883,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{HQWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, HQWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -905,7 +933,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use qwt::{HQWT256, SelectUnsigned};
+    /// use qwt::{SelectUnsigned, HQWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -917,7 +945,7 @@ where
     /// assert_eq!(qwt.select(1, 0), Some(0));
     /// assert_eq!(qwt.select(5, 0), Some(6));
     /// assert_eq!(qwt.select(6, 1), None);
-    /// ```    
+    /// ```
 
     #[inline(always)]
     fn select(&self, symbol: Self::Item, i: usize) -> Option<usize> {

--- a/src/quadwt/huffqwt.rs
+++ b/src/quadwt/huffqwt.rs
@@ -363,9 +363,7 @@ where
             prefetch_support: None,
             phantom_data: PhantomData,
         })
-
     }
-
 
     /// Returns an iterator over the values in the wavelet tree.
     ///

--- a/src/quadwt/huffqwt.rs
+++ b/src/quadwt/huffqwt.rs
@@ -329,11 +329,30 @@ where
         if WITH_PREFETCH_SUPPORT {
             return Err(crate::bytes::LayoutError::PrefetchNotSupported);
         }
-        if qvs.len() != n_levels || lens.len() != n_levels {
+        // Empty-tree convention from `new([])`: n_levels == 0 with a single
+        // default qv and lens=[0]. Callers may pass empty vecs; we normalize.
+        let (qvs, lens) = if n == 0 {
+            if n_levels != 0 {
+                return Err(crate::bytes::LayoutError::Inconsistent {
+                    detail: "empty tree must have n_levels == 0",
+                });
+            }
+            if qvs.is_empty() && lens.is_empty() {
+                (vec![RS::default()], vec![0])
+            } else if qvs.len() == 1 && lens == [0] {
+                (qvs, lens)
+            } else {
+                return Err(crate::bytes::LayoutError::Inconsistent {
+                    detail: "empty tree expects empty or default sentinel levels",
+                });
+            }
+        } else if qvs.len() != n_levels || lens.len() != n_levels {
             return Err(crate::bytes::LayoutError::Inconsistent {
                 detail: "n_levels disagrees with qvs/lens lengths",
             });
-        }
+        } else {
+            (qvs, lens)
+        };
         Ok(Self {
             n,
             n_levels,
@@ -344,6 +363,7 @@ where
             prefetch_support: None,
             phantom_data: PhantomData,
         })
+
     }
 
 

--- a/src/quadwt/huffqwt.rs
+++ b/src/quadwt/huffqwt.rs
@@ -3,12 +3,13 @@ use super::RSforWT;
 use crate::utils::stable_partition_of_4_with_codes;
 use crate::{
     AccessUnsigned, OccsRangeUnsigned, QVectorBuilder, RankUnsigned, SelectUnsigned, WTIndexable,
-    WTIterator,
+    WTIterator, MAX_QUAD_LEVELS,
 };
 use mem_dbg::{MemDbg, MemSize};
 use minimum_redundancy::{BitsPerFragment, Coding};
 use num_traits::AsPrimitive;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -23,7 +24,7 @@ pub struct PrefixCode {
 
 /// Implements a compressed wavelet tree on quad vectors.
 /// It doesn't achieve maximum compression, but the queries are faster
-#[derive(Default, Clone, PartialEq, Serialize, Deserialize, MemSize, MemDbg, Debug)]
+#[derive(Default, Clone, PartialEq, Serialize, MemSize, MemDbg, Debug)]
 pub struct HuffQWaveletTree<T, RS, const WITH_PREFETCH_SUPPORT: bool = false> {
     n: usize,                         // The length of the represented sequence
     n_levels: usize,                  // The number of levels of the wavelet matrix
@@ -35,20 +36,120 @@ pub struct HuffQWaveletTree<T, RS, const WITH_PREFETCH_SUPPORT: bool = false> {
     prefetch_support: Option<Vec<PrefetchSupport>>,
 }
 
-struct LenInfo(usize, u32); // symbol, len
+#[derive(Deserialize)]
+struct HuffQWaveletTreeSerde<T, RS> {
+    n: usize,
+    n_levels: usize,
+    codes_encode: Vec<PrefixCode>,
+    codes_decode: Vec<Vec<(u32, T)>>,
+    qvs: Vec<RS>,
+    lens: Vec<usize>,
+    phantom_data: PhantomData<T>,
+    prefetch_support: Option<Vec<PrefetchSupport>>,
+}
+
+impl<'de, T, RS, const WITH_PREFETCH_SUPPORT: bool> Deserialize<'de>
+    for HuffQWaveletTree<T, RS, WITH_PREFETCH_SUPPORT>
+where
+    T: WTIndexable + Deserialize<'de>,
+    usize: AsPrimitive<T>,
+    RS: RSforWT + Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let decoded = HuffQWaveletTreeSerde::<T, RS>::deserialize(deserializer)?;
+        let _ = decoded.phantom_data;
+        if WITH_PREFETCH_SUPPORT || decoded.prefetch_support.is_some() {
+            return Err(serde::de::Error::custom(
+                "deserializing prefetch-augmented Huffman QWT state is not supported",
+            ));
+        }
+        Self::from_parts(
+            decoded.n,
+            decoded.n_levels,
+            decoded.codes_encode,
+            decoded.codes_decode,
+            decoded.qvs,
+            decoded.lens,
+        )
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+struct LenInfo(usize, u32, usize); // symbol, len, frequency
+
+fn limit_code_lengths(lengths: &mut [LenInfo]) {
+    if !lengths.iter().any(|x| x.1 > u32::BITS) {
+        return;
+    }
+
+    // Represent the Kraft sum as occupied slots at the maximum depth. Capping
+    // an overwide leaf can overfill that depth, so lengthen the least-frequent
+    // shorter leaves just enough to make room. This retains useful short codes
+    // for common symbols instead of replacing the tree with fixed-width codes.
+    const MAX_CODE_BITS: u32 = u32::BITS;
+    const MAX_DEPTH_SLOTS: u128 = 1_u128 << MAX_CODE_BITS;
+    for LenInfo(_, len, _) in lengths.iter_mut() {
+        *len = (*len).min(MAX_CODE_BITS);
+    }
+    let mut occupied_slots = lengths
+        .iter()
+        .map(|x| 1_u128 << (MAX_CODE_BITS - x.1))
+        .sum::<u128>();
+    if occupied_slots <= MAX_DEPTH_SLOTS {
+        return;
+    }
+
+    let mut candidates = (0..lengths.len())
+        .filter(|&index| lengths[index].1 < MAX_CODE_BITS)
+        .collect::<Vec<_>>();
+    candidates.sort_unstable_by_key(|&index| {
+        let LenInfo(symbol, len, frequency) = lengths[index];
+        (frequency, len, symbol)
+    });
+    for index in candidates {
+        while occupied_slots > MAX_DEPTH_SLOTS && lengths[index].1 < MAX_CODE_BITS {
+            let old_slots = 1_u128 << (MAX_CODE_BITS - lengths[index].1);
+            lengths[index].1 += 2;
+            occupied_slots -= old_slots - old_slots / 4;
+        }
+        if occupied_slots <= MAX_DEPTH_SLOTS {
+            break;
+        }
+    }
+    assert!(
+        occupied_slots <= MAX_DEPTH_SLOTS,
+        "Huffman QWT alphabet exceeds the u32 code space"
+    );
+}
 
 #[allow(clippy::identity_op)]
-fn craft_wm_codes(freq: &mut HashMap<usize, u32>, sigma: usize) -> Vec<PrefixCode> {
-    // count size of the alphabet
-    let alph_size = freq.iter().count();
-
-    let mut f = freq
+fn craft_wm_codes(
+    lengths: &HashMap<usize, u32>,
+    frequencies: &HashMap<usize, usize>,
+    sigma: usize,
+) -> Vec<PrefixCode> {
+    let mut f = lengths
         .iter()
-        .map(|(&k, &v)| LenInfo(k, v * 2)) // each fragment is 2 bits
+        .map(|(&symbol, &len)| {
+            LenInfo(
+                symbol,
+                len * 2,
+                frequencies.get(&symbol).copied().unwrap_or_default(),
+            )
+        })
         .collect::<Vec<_>>();
+    craft_wm_codes_from_lengths(&mut f, sigma)
+}
 
-    f.sort_by_key(|x| x.1);
+#[allow(clippy::identity_op)]
+fn craft_wm_codes_from_lengths(f: &mut [LenInfo], sigma: usize) -> Vec<PrefixCode> {
+    limit_code_lengths(f);
+    f.sort_unstable_by_key(|x| (x.1, Reverse(x.2), x.0));
 
+    let alph_size = f.len();
     let mut c = vec![0; alph_size * 4];
     let mut assignments = vec![PrefixCode { content: 0, len: 0 }; sigma + 1];
     let mut m = 1; // how many codes we have so far
@@ -138,8 +239,7 @@ where
         // let tot_occs = sequence.len();
         // println!("total occurrences: {}", tot_occs);
 
-        let mut lengths =
-            Coding::from_frequencies_cloned(BitsPerFragment(2), &freqs).code_lengths();
+        let lengths = Coding::from_frequencies_cloned(BitsPerFragment(2), &freqs).code_lengths();
 
         // println!("lengths: {:?}", &lengths);
 
@@ -152,7 +252,7 @@ where
 
         // println!("awpl in bits: {}", awpl as f64 / tot_occs as f64);
 
-        let codes = craft_wm_codes(&mut lengths, sigma.as_());
+        let codes = craft_wm_codes(&lengths, &freqs, sigma.as_());
 
         // println!("{:?}", codes);
 
@@ -329,6 +429,11 @@ where
         if WITH_PREFETCH_SUPPORT {
             return Err(crate::bytes::LayoutError::PrefetchNotSupported);
         }
+        if n_levels > MAX_QUAD_LEVELS {
+            return Err(crate::bytes::LayoutError::Inconsistent {
+                detail: "Huffman QWT level count exceeds the supported maximum",
+            });
+        }
         // Empty-tree convention from `new([])`: n_levels == 0 with a single
         // default qv and lens=[0]. Callers may pass empty vecs; we normalize.
         let (qvs, lens) = if n == 0 {
@@ -346,13 +451,193 @@ where
                     detail: "empty tree expects empty or default sentinel levels",
                 });
             }
-        } else if qvs.len() != n_levels || lens.len() != n_levels {
+        } else if n_levels == 0 || qvs.len() != n_levels || lens.len() != n_levels {
             return Err(crate::bytes::LayoutError::Inconsistent {
                 detail: "n_levels disagrees with qvs/lens lengths",
             });
         } else {
             (qvs, lens)
         };
+        if n > 0 && lens.first().copied() != Some(n) {
+            return Err(crate::bytes::LayoutError::Inconsistent {
+                detail: "first Huffman QWT level length disagrees with header length",
+            });
+        }
+        if n > 0 {
+            for (level, &level_len) in qvs.iter().zip(&lens) {
+                let actual_len = (0..4u8)
+                    .map(|symbol| level.occs(symbol).unwrap_or(usize::MAX))
+                    .try_fold(0usize, usize::checked_add)
+                    .ok_or(crate::bytes::LayoutError::Inconsistent {
+                        detail: "Huffman QWT level occurrence counts overflow",
+                    })?;
+                if actual_len != level_len || level.rank(0, level_len).is_none() {
+                    return Err(crate::bytes::LayoutError::Inconsistent {
+                        detail: "Huffman QWT level payload length disagrees with directory",
+                    });
+                }
+            }
+        }
+        let max_code_bits = n_levels.saturating_mul(2);
+        for (symbol, code) in codes_encode.iter().enumerate() {
+            if code.len == 0 {
+                continue;
+            }
+            let code_len = code.len as usize;
+            if !code_len.is_multiple_of(2)
+                || code_len > max_code_bits
+                || code_len > u32::BITS as usize
+            {
+                return Err(crate::bytes::LayoutError::Inconsistent {
+                    detail: "Huffman encode code length is invalid",
+                });
+            }
+            if code_len < u32::BITS as usize && code.content >= (1u32 << code_len) {
+                return Err(crate::bytes::LayoutError::Inconsistent {
+                    detail: "Huffman encode code has bits outside its declared length",
+                });
+            }
+            let Some(bucket) = codes_decode.get(code_len) else {
+                return Err(crate::bytes::LayoutError::Inconsistent {
+                    detail: "Huffman decode bucket is missing",
+                });
+            };
+            let Ok(index) = bucket.binary_search_by_key(&code.content, |(content, _)| *content)
+            else {
+                return Err(crate::bytes::LayoutError::Inconsistent {
+                    detail: "Huffman encode code is absent from its decode bucket",
+                });
+            };
+            if bucket[index].1.as_() != symbol {
+                return Err(crate::bytes::LayoutError::Inconsistent {
+                    detail: "Huffman encode/decode symbol mapping disagrees",
+                });
+            }
+        }
+        for (code_len, bucket) in codes_decode.iter().enumerate() {
+            if bucket.windows(2).any(|pair| pair[0].0 >= pair[1].0) {
+                return Err(crate::bytes::LayoutError::Inconsistent {
+                    detail: "Huffman decode bucket must be strictly sorted",
+                });
+            }
+            for &(content, symbol) in bucket {
+                let Some(code) = codes_encode.get(symbol.as_()) else {
+                    return Err(crate::bytes::LayoutError::Inconsistent {
+                        detail: "Huffman decode symbol is outside the encode table",
+                    });
+                };
+                if code.len as usize != code_len || code.content != content {
+                    return Err(crate::bytes::LayoutError::Inconsistent {
+                        detail: "Huffman decode entry disagrees with its encode code",
+                    });
+                }
+            }
+        }
+        for code in codes_encode.iter().filter(|code| code.len != 0) {
+            let mut start = 0usize;
+            let mut end = n;
+            let mut shift = code.len as usize;
+            let mut level_index = 0usize;
+            while shift > 0 {
+                shift -= 2;
+                let Some(level) = qvs.get(level_index) else {
+                    return Err(crate::bytes::LayoutError::Inconsistent {
+                        detail: "Huffman code descends beyond available levels",
+                    });
+                };
+                if end > lens[level_index] {
+                    return Err(crate::bytes::LayoutError::Inconsistent {
+                        detail: "Huffman rank path exceeds a level length",
+                    });
+                }
+                let fragment = ((code.content >> shift) & 3) as u8;
+                start =
+                    level
+                        .rank(fragment, start)
+                        .ok_or(crate::bytes::LayoutError::Inconsistent {
+                            detail: "Huffman rank path start is invalid",
+                        })?
+                        + level.occs_smaller(fragment).unwrap_or(0);
+                end = level
+                    .rank(fragment, end)
+                    .ok_or(crate::bytes::LayoutError::Inconsistent {
+                        detail: "Huffman rank path end is invalid",
+                    })?
+                    + level.occs_smaller(fragment).unwrap_or(0);
+                level_index += 1;
+            }
+        }
+        // Validate every populated access path as a contiguous wavelet range.
+        // This proves the same property as decoding every row, but work scales
+        // with the Huffman prefix tree rather than the represented sequence.
+        let mut pending = if n == 0 {
+            Vec::new()
+        } else {
+            vec![(0usize, 0usize, n, 0u32, 0usize)]
+        };
+        while let Some((level_index, start, end, content, code_len)) = pending.pop() {
+            let Some(level) = qvs.get(level_index) else {
+                return Err(crate::bytes::LayoutError::Inconsistent {
+                    detail: "Huffman access path exceeds available levels",
+                });
+            };
+            if end > lens[level_index] {
+                return Err(crate::bytes::LayoutError::Inconsistent {
+                    detail: "Huffman access path exceeds a level",
+                });
+            }
+            // SAFETY: `start..end` was checked against this level's length;
+            // child ranges come from validated rank metadata and offsets.
+            let ranks_start = unsafe { level.rank_all_unchecked(start) };
+            let ranks_end = unsafe { level.rank_all_unchecked(end) };
+            for digit in 0..4usize {
+                if ranks_start[digit] == ranks_end[digit] {
+                    continue;
+                }
+                let child_content = (content << 2) | digit as u32;
+                let child_code_len = code_len + 2;
+                let has_decode = codes_decode.get(child_code_len).is_some_and(|bucket| {
+                    bucket
+                        .binary_search_by_key(&child_content, |(candidate, _)| *candidate)
+                        .is_ok()
+                });
+                let Some(next_level_len) = lens.get(level_index + 1).copied() else {
+                    if !has_decode {
+                        return Err(crate::bytes::LayoutError::Inconsistent {
+                            detail: "Huffman access path has no decode entry",
+                        });
+                    }
+                    continue;
+                };
+                let offset = level.occs_smaller(digit as u8).unwrap_or(0);
+                let child_start = offset + ranks_start[digit];
+                let child_end = offset + ranks_end[digit];
+                if child_end <= next_level_len {
+                    if has_decode {
+                        return Err(crate::bytes::LayoutError::Inconsistent {
+                            detail: "Huffman decode entry has a populated descendant",
+                        });
+                    }
+                    pending.push((
+                        level_index + 1,
+                        child_start,
+                        child_end,
+                        child_content,
+                        child_code_len,
+                    ));
+                } else if child_start >= next_level_len {
+                    if !has_decode {
+                        return Err(crate::bytes::LayoutError::Inconsistent {
+                            detail: "Huffman access path has no decode entry",
+                        });
+                    }
+                } else {
+                    return Err(crate::bytes::LayoutError::Inconsistent {
+                        detail: "Huffman prefix is split across terminal and continuing rows",
+                    });
+                }
+            }
+        }
         Ok(Self {
             n,
             n_levels,

--- a/src/quadwt/huffqwt/tests.rs
+++ b/src/quadwt/huffqwt/tests.rs
@@ -1,10 +1,9 @@
-use rand::RngExt;
-
+use crate::perf_and_test_utils::{gen_sequence, TimingQueries};
 use crate::{
-    perf_and_test_utils::{gen_sequence, TimingQueries},
     AccessUnsigned, HuffQWaveletTree, OccsRangeUnsigned, RSQVector512, RankUnsigned,
     SelectUnsigned, HQWT256,
 };
+use rand::RngExt;
 
 #[test]
 fn test_small() {

--- a/src/quadwt/huffqwt/tests.rs
+++ b/src/quadwt/huffqwt/tests.rs
@@ -44,8 +44,12 @@ fn test_occs_range() {
     assert!(qwt.occs_range(data.len() - 1..data.len() + 1).is_none());
 
     // nonsense ranges
-    assert!(qwt.occs_range(5..4).is_none());
-    assert!(qwt.occs_range(2..0).is_none());
+    assert!(qwt
+        .occs_range(std::ops::Range { start: 5, end: 4 })
+        .is_none());
+    assert!(qwt
+        .occs_range(std::ops::Range { start: 2, end: 0 })
+        .is_none());
 
     // empty ranges
     assert_eq!(0, qwt.occs_range(data.len()..).unwrap().count());

--- a/src/quadwt/huffqwt/tests.rs
+++ b/src/quadwt/huffqwt/tests.rs
@@ -1,9 +1,50 @@
+use super::{craft_wm_codes_from_lengths, LenInfo};
 use crate::perf_and_test_utils::{gen_sequence, TimingQueries};
 use crate::{
     AccessUnsigned, HuffQWaveletTree, OccsRangeUnsigned, RSQVector512, RankUnsigned,
     SelectUnsigned, HQWT256,
 };
 use rand::RngExt;
+
+#[test]
+fn overwide_huffman_lengths_are_limited_without_flattening_common_codes() {
+    // A complete quaternary tree with one internal child at each level: three
+    // leaves at depths 1..=16 and four leaves at depth 17. The old code would
+    // shift by 32 while constructing this valid 34-bit code set.
+    let mut lengths = Vec::new();
+    let mut symbol = 0;
+    for depth in 1..=16 {
+        for _ in 0..3 {
+            lengths.push(LenInfo(symbol, depth * 2, 1 << (17 - depth)));
+            symbol += 1;
+        }
+    }
+    for _ in 0..4 {
+        lengths.push(LenInfo(symbol, 34, 1));
+        symbol += 1;
+    }
+
+    let codes = craft_wm_codes_from_lengths(&mut lengths, symbol - 1);
+    assert!(codes.iter().all(|code| code.len <= 32));
+    assert!(codes.iter().all(|code| code.len.is_multiple_of(2)));
+    assert!(codes.iter().any(|code| code.len == 2));
+
+    let occupied_slots = codes
+        .iter()
+        .map(|code| 1_u64 << (u32::BITS - code.len))
+        .sum::<u64>();
+    assert!(occupied_slots <= 1_u64 << u32::BITS);
+    for (left_index, left) in codes.iter().enumerate() {
+        for right in &codes[left_index + 1..] {
+            let (short, long) = if left.len <= right.len {
+                (left, right)
+            } else {
+                (right, left)
+            };
+            assert_ne!(short.content, long.content >> (long.len - short.len));
+        }
+    }
+}
 
 #[test]
 fn test_small() {

--- a/src/quadwt/mod.rs
+++ b/src/quadwt/mod.rs
@@ -272,6 +272,37 @@ where
         self.sigma
     }
 
+    /// Assemble a tree from prebuilt levels.
+    ///
+    /// Inverse of [`levels`](Self::levels) + [`len`](Self::len) +
+    /// [`sigma_raw`](Self::sigma_raw). Used by zero-copy I/O.
+    ///
+    /// Prefetch-augmented trees (`WITH_PREFETCH_SUPPORT = true`) are rejected
+    /// in v1 of the byte format.
+    pub fn from_parts(
+        n: usize,
+        sigma: T,
+        qvs: Vec<RS>,
+    ) -> Result<Self, crate::bytes::LayoutError> {
+        if WITH_PREFETCH_SUPPORT {
+            return Err(crate::bytes::LayoutError::PrefetchNotSupported);
+        }
+        let n_levels = qvs.len();
+        if n == 0 && n_levels > 1 {
+            return Err(crate::bytes::LayoutError::Inconsistent {
+                detail: "empty tree cannot have more than one (default) level",
+            });
+        }
+        Ok(Self {
+            n,
+            n_levels,
+            sigma,
+            qvs,
+            prefetch_support: None,
+        })
+    }
+
+
     /// Smallest symbol in `range` that is `>= target`, or `None` if no such
     /// symbol occurs. Half-open row range `[start, end)`.
     ///

--- a/src/quadwt/mod.rs
+++ b/src/quadwt/mod.rs
@@ -35,7 +35,6 @@
 //! assert_eq!(qwt.rank(3, 7), Some(1));  // Counts the occurrences of symbol 3 up to position 7, should return 1
 //! assert_eq!(qwt.select(3, 0), Some(2));  // Finds the position of the 1st occurrence of symbol 3, should return Some(2)
 //! ```
-
 use crate::utils::{msb, stable_partition_of_4};
 use crate::{
     AccessUnsigned, OccsRangeUnsigned, RankUnsigned, SelectUnsigned, WTIterator, WTSupport,
@@ -1087,7 +1086,6 @@ where
     /// assert_eq!(qwt.rank(1, 9), None); // Too large position
     /// assert_eq!(qwt.rank(6, 1), None); // Too large symbol
     /// ```
-
     #[inline(always)]
     fn rank(&self, symbol: Self::Item, i: usize) -> Option<usize> {
         if i > self.n || symbol > self.sigma {
@@ -1121,7 +1119,6 @@ where
     ///     assert_eq!(qwt.rank_unchecked(1, 2), 1);
     /// }
     /// ```
-
     #[inline(always)]
     unsafe fn rank_unchecked(&self, symbol: Self::Item, i: usize) -> usize {
         let mut shift: i64 = (2 * (self.n_levels - 1)) as i64;
@@ -1174,7 +1171,6 @@ where
     /// assert_eq!(qwt.get(3), Some(0));
     /// assert_eq!(qwt.get(8), None);
     /// ```
-
     #[inline(always)]
     fn get(&self, i: usize) -> Option<Self::Item> {
         if i >= self.n {
@@ -1205,7 +1201,6 @@ where
     ///     assert_eq!(qwt.get_unchecked(3), 0);
     /// }
     /// ```
-
     #[inline(always)]
     unsafe fn get_unchecked(&self, i: usize) -> Self::Item {
         let mut result = T::zero();
@@ -1255,7 +1250,6 @@ where
     /// assert_eq!(qwt.select(5, 0), Some(6));
     /// assert_eq!(qwt.select(6, 1), None);
     /// ```
-
     #[inline(always)]
     fn select(&self, symbol: Self::Item, i: usize) -> Option<usize> {
         if symbol > self.sigma {
@@ -1305,7 +1299,6 @@ where
     ///
     /// In the current implementation, there is no efficiency reason to prefer this
     /// unsafe `select` over the safe one.
-
     #[inline(always)]
     unsafe fn select_unchecked(&self, symbol: Self::Item, i: usize) -> usize {
         self.select(symbol, i).unwrap()

--- a/src/quadwt/mod.rs
+++ b/src/quadwt/mod.rs
@@ -309,8 +309,6 @@ where
         })
     }
 
-
-
     /// Smallest symbol in `range` that is `>= target`, or `None` if no such
     /// symbol occurs. Half-open row range `[start, end)`.
     ///

--- a/src/quadwt/mod.rs
+++ b/src/quadwt/mod.rs
@@ -281,16 +281,23 @@ where
     /// in v1 of the byte format.
     pub fn from_parts(
         n: usize,
+        n_levels: usize,
         sigma: T,
         qvs: Vec<RS>,
     ) -> Result<Self, crate::bytes::LayoutError> {
         if WITH_PREFETCH_SUPPORT {
             return Err(crate::bytes::LayoutError::PrefetchNotSupported);
         }
-        let n_levels = qvs.len();
-        if n == 0 && n_levels > 1 {
+        // Empty-tree convention from `new([])`: n_levels == 0 with a single default qv.
+        if n == 0 {
+            if n_levels != 0 {
+                return Err(crate::bytes::LayoutError::Inconsistent {
+                    detail: "empty tree must have n_levels == 0",
+                });
+            }
+        } else if qvs.len() != n_levels {
             return Err(crate::bytes::LayoutError::Inconsistent {
-                detail: "empty tree cannot have more than one (default) level",
+                detail: "n_levels disagrees with qvs length",
             });
         }
         Ok(Self {
@@ -301,6 +308,7 @@ where
             prefetch_support: None,
         })
     }
+
 
 
     /// Smallest symbol in `range` that is `>= target`, or `None` if no such

--- a/src/quadwt/mod.rs
+++ b/src/quadwt/mod.rs
@@ -41,13 +41,11 @@ use crate::{
     AccessUnsigned, OccsRangeUnsigned, RankUnsigned, SelectUnsigned, WTIterator, WTSupport,
 };
 use crate::{QVector, QVectorBuilder}; // Traits
-
 use mem_dbg::{MemDbg, MemSize};
-use serde::{Deserialize, Serialize};
-use std::marker::PhantomData;
-
 // Traits bound
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 use std::ops::{Bound, Range, RangeBounds, Shl, Shr};
 
 pub mod huffqwt;
@@ -260,6 +258,220 @@ where
         self.n_levels
     }
 
+    /// Per-level RS quad vectors (read-only).
+    ///
+    /// Exposed for zero-copy / mmap flatten of the tree layout.
+    #[inline]
+    pub fn levels(&self) -> &[RS] {
+        &self.qvs
+    }
+
+    /// Largest symbol (qwt convention: not +1).
+    #[inline]
+    pub fn sigma_raw(&self) -> T {
+        self.sigma
+    }
+
+    /// Smallest symbol in `range` that is `>= target`, or `None` if no such
+    /// symbol occurs. Half-open row range `[start, end)`.
+    ///
+    /// # Complexity
+    /// Guided top-down walk over the wavelet matrix using only per-level
+    /// 4-ary ranks. Worst case `O(n_levels)` with a constant number of
+    /// branch ranks per level — **not** `O(|range|)` and **not**
+    /// enumeration of all distinct symbols less than `target`.
+    ///
+    /// # Space
+    /// Zero additional persistent data; uses a fixed stack of size
+    /// `n_levels` (≤ 32 on this type's addressable alphabets).
+    ///
+    /// # Examples
+    /// ```
+    /// use qwt::QWT256;
+    ///
+    /// let qwt = QWT256::from(vec![1u8, 0, 1, 0, 2, 4, 5, 3]);
+    /// assert_eq!(qwt.range_next_value(0..8, 0u8), Some(0));
+    /// assert_eq!(qwt.range_next_value(0..8, 3u8), Some(3));
+    /// assert_eq!(qwt.range_next_value(0..8, 6u8), None);
+    /// assert_eq!(qwt.range_next_value(0..0, 0u8), None);
+    /// ```
+    #[must_use]
+    pub fn range_next_value(&self, range: Range<usize>, target: T) -> Option<T> {
+        if range.start > range.end || range.end > self.n || range.start == range.end {
+            return None;
+        }
+        if self.n_levels == 0 {
+            return None;
+        }
+        // SAFETY: bounds checked above
+        unsafe { self.range_next_value_unchecked(range, target) }
+    }
+
+    /// Unchecked variant of [`Self::range_next_value`].
+    ///
+    /// # Safety
+    /// `range` must be a valid half-open subrange of `[0, len()]`.
+    #[must_use]
+    pub unsafe fn range_next_value_unchecked(&self, range: Range<usize>, target: T) -> Option<T> {
+        // Guided successor on the wavelet matrix.
+        //
+        // At level `ℓ` the current symbol interval [sym_lo, sym_hi) is split into
+        // 4 equal-width child intervals (2 bits). We only enter a child if the
+        // projected row interval is nonempty AND the child symbol interval
+        // intersects [target, +∞). Among viable children we try left-to-right
+        // (smallest first), with a fixed stack for backtracking.
+        //
+        // This matches the encoding used by `get`/`rank` (MSB-first 2-bit digits
+        // over `n_levels` levels), so leaf `sym_lo` is the decoded symbol.
+        #[derive(Clone, Copy)]
+        struct Frame {
+            start: usize,
+            end: usize,
+            level: usize,
+            sym_lo: usize,
+            // width of this node's alphabet interval = 4^(n_levels - level)
+            // stored as log2_width = 2 * (n_levels - level)
+            log2_width: u32,
+        }
+
+        let n_levels = self.n_levels;
+        let target_us: usize = target.as_();
+
+        // Full universe width is 4^n_levels = 2^(2*n_levels).
+        let full_log2: u32 = 2 * n_levels as u32;
+
+        let mut stack = [Frame {
+            start: 0,
+            end: 0,
+            level: 0,
+            sym_lo: 0,
+            log2_width: 0,
+        }; 128];
+        let mut sp: usize = 1;
+        stack[0] = Frame {
+            start: range.start,
+            end: range.end,
+            level: 0,
+            sym_lo: 0,
+            log2_width: full_log2,
+        };
+
+        while sp > 0 {
+            sp -= 1;
+            let cur = stack[sp];
+
+            if cur.start >= cur.end {
+                continue;
+            }
+
+            // Leaf: single symbol interval of width 1.
+            if cur.log2_width == 0 {
+                if cur.sym_lo >= target_us {
+                    return Some(cur.sym_lo.as_());
+                }
+                continue;
+            }
+
+            // SAFETY: level < n_levels when log2_width > 0
+            let qv = unsafe { self.qvs.get_unchecked(cur.level) };
+            let child_log = cur.log2_width - 2;
+            let child_width = 1usize << child_log;
+
+            // Collect viable children b=0..3 left-to-right, then push reverse.
+            let mut cand_b = [0u8; 4];
+            let mut cand_s = [0usize; 4];
+            let mut cand_e = [0usize; 4];
+            let mut cand_lo = [0usize; 4];
+            let mut nc = 0usize;
+
+            for b in 0..4u8 {
+                let child_sym_lo = cur.sym_lo + (b as usize) * child_width;
+                let child_sym_hi = child_sym_lo + child_width;
+                // Child entirely < target → skip.
+                if child_sym_hi <= target_us {
+                    continue;
+                }
+                let lo = unsafe { qv.rank_unchecked(b, cur.start) };
+                let hi = unsafe { qv.rank_unchecked(b, cur.end) };
+                if hi > lo {
+                    let offset = unsafe { qv.occs_smaller_unchecked(b) };
+                    cand_b[nc] = b;
+                    cand_s[nc] = offset + lo;
+                    cand_e[nc] = offset + hi;
+                    cand_lo[nc] = child_sym_lo;
+                    nc += 1;
+                }
+            }
+
+            for i in (0..nc).rev() {
+                debug_assert!(sp < 128);
+                stack[sp] = Frame {
+                    start: cand_s[i],
+                    end: cand_e[i],
+                    level: cur.level + 1,
+                    sym_lo: cand_lo[i],
+                    log2_width: child_log,
+                };
+                sp += 1;
+            }
+        }
+
+        None
+    }
+
+    /// Linear-scan oracle for [`Self::range_next_value`] (diagnostic / test only).
+    ///
+    /// Complexity `O(|range| · log σ)` via repeated `get`. Not for hot paths.
+    #[cfg(test)]
+    #[must_use]
+    pub fn range_next_value_scan(&self, range: Range<usize>, target: T) -> Option<T> {
+        if range.start > range.end || range.end > self.n || range.start == range.end {
+            return None;
+        }
+        let mut best: Option<T> = None;
+        for i in range.start..range.end {
+            // SAFETY: i < range.end ≤ n
+            let v = unsafe { self.get_unchecked(i) };
+            if v >= target {
+                best = Some(match best {
+                    Some(b) if b <= v => b,
+                    _ => v,
+                });
+                if best == Some(target) {
+                    return Some(target);
+                }
+            }
+        }
+        best
+    }
+
+    /// Stateful distinct-symbol enumerator over a row range.
+    ///
+    /// Yields `(symbol, count)` in lexicographic order for every symbol that
+    /// occurs at least once in `range`. Uses a **fixed** O(log σ) stack —
+    /// no `Vec`, no eager collection, no work proportional to full row-range
+    /// length beyond ranks on the projected wavelet path.
+    ///
+    /// This is the wavelet analogue of opening a LOUDS sibling range once and
+    /// advancing through it: successive `next` calls amortize the tree walk
+    /// instead of restarting a full root-to-leaf search per successor
+    /// (`range_next_value(prev+1)`).
+    ///
+    /// # Examples
+    /// ```
+    /// use qwt::QWT256;
+    /// let qwt = QWT256::from(vec![1u8, 0, 1, 0, 2, 4, 5, 3]);
+    /// let got: Vec<_> = qwt.range_distinct_iter(0..8).collect();
+    /// assert_eq!(got, vec![(0, 2), (1, 2), (2, 1), (3, 1), (4, 1), (5, 1)]);
+    /// ```
+    #[must_use]
+    pub fn range_distinct_iter(
+        &self,
+        range: Range<usize>,
+    ) -> RangeDistinctIter<'_, T, RS, WITH_PREFETCH_SUPPORT> {
+        RangeDistinctIter::new(self, range)
+    }
+
     /// Returns an iterator over the values in the wavelet tree.
     ///
     /// # Examples
@@ -273,7 +485,10 @@ where
     ///
     /// assert_eq!(qwt.iter().collect::<Vec<_>>(), data);
     ///
-    /// assert_eq!(qwt.iter().rev().collect::<Vec<_>>(), data.into_iter().rev().collect::<Vec<_>>());
+    /// assert_eq!(
+    ///     qwt.iter().rev().collect::<Vec<_>>(),
+    ///     data.into_iter().rev().collect::<Vec<_>>()
+    /// );
     /// ```
     pub fn iter(
         &self,
@@ -383,7 +598,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{QWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, QWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -392,8 +607,8 @@ where
     /// assert_eq!(qwt.rank_prefetch(1, 2), Some(1));
     /// assert_eq!(qwt.rank_prefetch(3, 8), Some(1));
     /// assert_eq!(qwt.rank_prefetch(1, 0), Some(0));
-    /// assert_eq!(qwt.rank_prefetch(1, 9), None);  // Too large position
-    /// assert_eq!(qwt.rank_prefetch(6, 1), None);  // Too large symbol
+    /// assert_eq!(qwt.rank_prefetch(1, 9), None); // Too large position
+    /// assert_eq!(qwt.rank_prefetch(6, 1), None); // Too large symbol
     /// ```
     #[inline(always)]
     #[must_use]
@@ -419,7 +634,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use qwt::{QWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, QWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -629,6 +844,185 @@ where
     }
 }
 
+// ── RangeDistinctIter (fixed-stack stateful distinct enumeration) ──
+
+/// Fixed-stack distinct-symbol iterator over a wavelet row range.
+///
+/// Same DFS order as [`OccsRangeIter`], but stack is a fixed array of size 128
+/// (≤ 4·n_levels frames in practice). Zero persistent bytes on the tree.
+pub struct RangeDistinctIter<'a, T, RS, const WITH_PREFETCH_SUPPORT: bool> {
+    tree: &'a QWaveletTree<T, RS, WITH_PREFETCH_SUPPORT>,
+    /// DFS stack; only `sp` slots are live.
+    stack: [RangeDistinctFrame; 128],
+    sp: usize,
+    /// Optional profiling counters (rank probes, frames, children).
+    pub rank_probes: u64,
+    pub frames_popped: u64,
+    pub children_pushed: u64,
+    /// Number of 4-ary child slots tested that were empty (hi==lo).
+    pub empty_branches: u64,
+    /// Nonempty children pushed (alias of children_pushed for clarity).
+    pub branch_transitions: u64,
+    /// Leaf yields (symbols returned).
+    pub symbols_yielded: u64,
+}
+
+#[derive(Clone, Copy, Default)]
+struct RangeDistinctFrame {
+    start: usize,
+    end: usize,
+    level: usize,
+    bit_path: usize,
+}
+
+impl<'a, T, RS, const WITH_PREFETCH_SUPPORT: bool>
+    RangeDistinctIter<'a, T, RS, WITH_PREFETCH_SUPPORT>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+    RS: RSforWT,
+{
+    fn new(tree: &'a QWaveletTree<T, RS, WITH_PREFETCH_SUPPORT>, range: Range<usize>) -> Self {
+        let mut stack = [RangeDistinctFrame::default(); 128];
+        let mut sp = 0usize;
+        if range.start < range.end && range.end <= tree.n && tree.n_levels > 0 {
+            stack[0] = RangeDistinctFrame {
+                start: range.start,
+                end: range.end,
+                level: 0,
+                bit_path: 0,
+            };
+            sp = 1;
+        }
+        Self {
+            tree,
+            stack,
+            sp,
+            rank_probes: 0,
+            frames_popped: 0,
+            children_pushed: 0,
+            empty_branches: 0,
+            branch_transitions: 0,
+            symbols_yielded: 0,
+        }
+    }
+
+    /// Returns the next distinct symbol and its occurrence count in the range.
+    ///
+    /// Optimizations:
+    /// - **Rank-all-4** at start/end (shared data-line loads).
+    /// - **Unary path collapse**: when exactly one child is nonempty, descend
+    ///   in-place without stack push/pop until a branch or leaf.
+    #[inline]
+    pub fn next_symbol(&mut self) -> Option<(T, usize)> {
+        while self.sp > 0 {
+            self.sp -= 1;
+            let mut cur = self.stack[self.sp];
+            self.frames_popped += 1;
+
+            if cur.start >= cur.end {
+                continue;
+            }
+
+            // Leaf: full bit_path is the symbol; range length is the count.
+            if cur.level == self.tree.n_levels {
+                self.symbols_yielded += 1;
+                return Some((cur.bit_path.as_(), cur.end - cur.start));
+            }
+
+            // Expand current frame; collapse unary chains without re-stacking.
+            loop {
+                // SAFETY: level < n_levels
+                let qv = unsafe { self.tree.qvs.get_unchecked(cur.level) };
+
+                // Prefetch superblock + data lines for both endpoints before bulk rank.
+                qv.prefetch_info(cur.start);
+                qv.prefetch_info(cur.end);
+                qv.prefetch_data(cur.start);
+                qv.prefetch_data(cur.end);
+
+                // Shared rank-all at both endpoints (2 bulk probes vs 8 singles).
+                let ranks_s = unsafe { qv.rank_all_unchecked(cur.start) };
+                let ranks_e = unsafe { qv.rank_all_unchecked(cur.end) };
+                self.rank_probes += 2;
+
+                let mut cand_s = [0usize; 4];
+                let mut cand_e = [0usize; 4];
+                let mut cand_path = [0usize; 4];
+                let mut cand_b = [0u8; 4];
+                let mut nc = 0usize;
+
+                for b in 0..4u8 {
+                    let lo = ranks_s[b as usize];
+                    let hi = ranks_e[b as usize];
+                    if hi > lo {
+                        let offset = unsafe { qv.occs_smaller_unchecked(b) };
+                        cand_s[nc] = offset + lo;
+                        cand_e[nc] = offset + hi;
+                        cand_path[nc] = (cur.bit_path << 2) | (b as usize);
+                        cand_b[nc] = b;
+                        nc += 1;
+                    } else {
+                        self.empty_branches += 1;
+                    }
+                }
+
+                if nc == 0 {
+                    break; // no children — dead frame
+                }
+
+                // Unary path collapse: one live child → descend in-place,
+                // skip stack traffic until a branch or leaf.
+                if nc == 1 {
+                    cur.start = cand_s[0];
+                    cur.end = cand_e[0];
+                    cur.bit_path = cand_path[0];
+                    cur.level += 1;
+                    self.children_pushed += 1;
+                    self.branch_transitions += 1;
+                    if cur.level == self.tree.n_levels {
+                        self.symbols_yielded += 1;
+                        return Some((cur.bit_path.as_(), cur.end - cur.start));
+                    }
+                    continue;
+                }
+
+                // Branch: push children reverse for lex order.
+                for i in (0..nc).rev() {
+                    debug_assert!(self.sp < 128);
+                    self.stack[self.sp] = RangeDistinctFrame {
+                        start: cand_s[i],
+                        end: cand_e[i],
+                        level: cur.level + 1,
+                        bit_path: cand_path[i],
+                    };
+                    self.sp += 1;
+                    self.children_pushed += 1;
+                    self.branch_transitions += 1;
+                }
+                let _ = cand_b;
+                break;
+            }
+        }
+        None
+    }
+}
+
+impl<'a, T, RS, const WITH_PREFETCH_SUPPORT: bool> Iterator
+    for RangeDistinctIter<'a, T, RS, WITH_PREFETCH_SUPPORT>
+where
+    T: WTIndexable,
+    usize: AsPrimitive<T>,
+    RS: RSforWT,
+{
+    type Item = (T, usize);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_symbol()
+    }
+}
+
 impl<T, RS, const WITH_PREFETCH_SUPPORT: bool> RankUnsigned
     for QWaveletTree<T, RS, WITH_PREFETCH_SUPPORT>
 where
@@ -644,7 +1038,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{QWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, QWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -653,8 +1047,8 @@ where
     /// assert_eq!(qwt.rank(1, 2), Some(1));
     /// assert_eq!(qwt.rank(3, 8), Some(1));
     /// assert_eq!(qwt.rank(1, 0), Some(0));
-    /// assert_eq!(qwt.rank(1, 9), None);  // Too large position
-    /// assert_eq!(qwt.rank(6, 1), None);  // Too large symbol
+    /// assert_eq!(qwt.rank(1, 9), None); // Too large position
+    /// assert_eq!(qwt.rank(6, 1), None); // Too large symbol
     /// ```
 
     #[inline(always)]
@@ -680,7 +1074,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{QWT256, RankUnsigned};
+    /// use qwt::{RankUnsigned, QWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -733,7 +1127,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use qwt::{QWT256, AccessUnsigned};
+    /// use qwt::{AccessUnsigned, QWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -763,7 +1157,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use qwt::{QWT256, AccessUnsigned};
+    /// use qwt::{AccessUnsigned, QWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -811,7 +1205,7 @@ where
     ///
     /// # Examples
     /// ```
-    /// use qwt::{QWT256, SelectUnsigned};
+    /// use qwt::{SelectUnsigned, QWT256};
     ///
     /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
     ///
@@ -823,7 +1217,7 @@ where
     /// assert_eq!(qwt.select(1, 0), Some(0));
     /// assert_eq!(qwt.select(5, 0), Some(6));
     /// assert_eq!(qwt.select(6, 1), None);
-    /// ```    
+    /// ```
 
     #[inline(always)]
     fn select(&self, symbol: Self::Item, i: usize) -> Option<usize> {

--- a/src/quadwt/mod.rs
+++ b/src/quadwt/mod.rs
@@ -38,12 +38,13 @@
 use crate::utils::{msb, stable_partition_of_4};
 use crate::{
     AccessUnsigned, OccsRangeUnsigned, RankUnsigned, SelectUnsigned, WTIterator, WTSupport,
+    MAX_QUAD_LEVELS,
 };
 use crate::{QVector, QVectorBuilder}; // Traits
 use mem_dbg::{MemDbg, MemSize};
 // Traits bound
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::marker::PhantomData;
 use std::ops::{Bound, Range, RangeBounds, Shl, Shr};
 
@@ -82,13 +83,44 @@ where
 /// is augmented with extra data to support a deeper level of prefetching.
 /// This extra informationa are needed only for sequences such that data
 /// about superblocks and blocks do not fit in L3 cache.
-#[derive(Default, Clone, PartialEq, Debug, Serialize, MemSize, MemDbg, Deserialize)]
+#[derive(Default, Clone, PartialEq, Debug, Serialize, MemSize, MemDbg)]
 pub struct QWaveletTree<T, RS, const WITH_PREFETCH_SUPPORT: bool = false> {
     n: usize,        // The length of the represented sequence
     n_levels: usize, // The number of levels of the wavelet matrix
     sigma: T, // The largest symbol in the sequence. *NOTE*: It's not +1 because it may overflow
     qvs: Vec<RS>, // A quad vector for each level
     prefetch_support: Option<Vec<PrefetchSupport>>,
+}
+
+#[derive(Deserialize)]
+struct QWaveletTreeSerde<T, RS> {
+    n: usize,
+    n_levels: usize,
+    sigma: T,
+    qvs: Vec<RS>,
+    prefetch_support: Option<Vec<PrefetchSupport>>,
+}
+
+impl<'de, T, RS, const WITH_PREFETCH_SUPPORT: bool> Deserialize<'de>
+    for QWaveletTree<T, RS, WITH_PREFETCH_SUPPORT>
+where
+    T: WTIndexable + Deserialize<'de>,
+    usize: AsPrimitive<T>,
+    RS: RSforWT + Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let decoded = QWaveletTreeSerde::<T, RS>::deserialize(deserializer)?;
+        if WITH_PREFETCH_SUPPORT || decoded.prefetch_support.is_some() {
+            return Err(serde::de::Error::custom(
+                "deserializing prefetch-augmented QWT state is not supported",
+            ));
+        }
+        Self::from_parts(decoded.n, decoded.n_levels, decoded.sigma, decoded.qvs)
+            .map_err(serde::de::Error::custom)
+    }
 }
 
 impl<T, RS, const WITH_PREFETCH_SUPPORT: bool> QWaveletTree<T, RS, WITH_PREFETCH_SUPPORT>
@@ -287,17 +319,80 @@ where
         if WITH_PREFETCH_SUPPORT {
             return Err(crate::bytes::LayoutError::PrefetchNotSupported);
         }
+        let max_type_levels = (std::mem::size_of::<T>() * u8::BITS as usize).div_ceil(2);
+        if n_levels > MAX_QUAD_LEVELS || n_levels > max_type_levels {
+            return Err(crate::bytes::LayoutError::Inconsistent {
+                detail: "QWT level count exceeds the supported maximum",
+            });
+        }
         // Empty-tree convention from `new([])`: n_levels == 0 with a single default qv.
         if n == 0 {
-            if n_levels != 0 {
+            if n_levels != 0 || sigma != T::zero() {
                 return Err(crate::bytes::LayoutError::Inconsistent {
-                    detail: "empty tree must have n_levels == 0",
+                    detail: "empty tree must have zero sigma and zero levels",
                 });
             }
-        } else if qvs.len() != n_levels {
+        } else if n_levels == 0 || qvs.len() != n_levels {
             return Err(crate::bytes::LayoutError::Inconsistent {
                 detail: "n_levels disagrees with qvs length",
             });
+        }
+        if n > 0 {
+            let expected_levels = (msb(sigma) + 1).div_ceil(2) as usize;
+            if n_levels != expected_levels {
+                return Err(crate::bytes::LayoutError::Inconsistent {
+                    detail: "n_levels disagrees with sigma",
+                });
+            }
+            for level in &qvs {
+                let level_len = (0..4u8)
+                    .map(|symbol| level.occs(symbol).unwrap_or(usize::MAX))
+                    .try_fold(0usize, usize::checked_add)
+                    .ok_or(crate::bytes::LayoutError::Inconsistent {
+                        detail: "QWT level occurrence counts overflow",
+                    })?;
+                if level_len != n || level.rank(0, n).is_none() {
+                    return Err(crate::bytes::LayoutError::Inconsistent {
+                        detail: "QWT level length disagrees with header length",
+                    });
+                }
+            }
+            let mut actual_sigma = T::zero();
+            for index in 0..n {
+                let mut value = T::zero();
+                let mut current = index;
+                for (level_index, level) in qvs.iter().enumerate() {
+                    let symbol = crate::AccessQuad::get(level, current).ok_or(
+                        crate::bytes::LayoutError::Inconsistent {
+                            detail: "QWT payload transition is out of bounds",
+                        },
+                    )?;
+                    value = (value << 2) | (symbol as usize).as_();
+                    if level_index + 1 < n_levels {
+                        let offset = level.occs_smaller(symbol).ok_or(
+                            crate::bytes::LayoutError::Inconsistent {
+                                detail: "QWT payload contains an invalid symbol",
+                            },
+                        )?;
+                        let rank = crate::RankQuad::rank(level, symbol, current).ok_or(
+                            crate::bytes::LayoutError::Inconsistent {
+                                detail: "QWT payload rank metadata is invalid",
+                            },
+                        )?;
+                        current = offset.checked_add(rank).ok_or(
+                            crate::bytes::LayoutError::Inconsistent {
+                                detail: "QWT payload transition overflows",
+                            },
+                        )?;
+                    }
+                }
+                actual_sigma = actual_sigma.max(value);
+            }
+            if actual_sigma != sigma {
+                return Err(crate::bytes::LayoutError::Inconsistent {
+                    detail: "sigma disagrees with the encoded QWT payload",
+                });
+            }
         }
         Ok(Self {
             n,
@@ -1050,20 +1145,13 @@ where
             let child_start = offset + ranks_s[b];
             let child_end = child_start + cnt;
             let child_prefix: T = (prefix << 2) | b.as_();
-            self.extract_range_distinct_rec(
-                level + 1,
-                child_start,
-                child_end,
-                child_prefix,
-                out,
-            );
+            self.extract_range_distinct_rec(level + 1, child_start, child_end, child_prefix, out);
         }
     }
 }
 
 impl<T, RS, const WITH_PREFETCH_SUPPORT: bool> OccsRangeUnsigned
     for QWaveletTree<T, RS, WITH_PREFETCH_SUPPORT>
-
 where
     T: WTIndexable,
     usize: AsPrimitive<T>,
@@ -1397,6 +1485,9 @@ where
         if i > self.n || symbol > self.sigma {
             return None;
         }
+        if self.n_levels == 0 {
+            return Some(0);
+        }
 
         // SAFETY: Check above guarantees we are not out of bound
         Some(unsafe { self.rank_unchecked(symbol, i) })
@@ -1427,6 +1518,9 @@ where
     /// ```
     #[inline(always)]
     unsafe fn rank_unchecked(&self, symbol: Self::Item, i: usize) -> usize {
+        if self.n_levels == 0 {
+            return 0;
+        }
         let mut shift: i64 = (2 * (self.n_levels - 1)) as i64;
         let mut cur_i = i;
         let mut cur_p = 0;

--- a/src/quadwt/mod.rs
+++ b/src/quadwt/mod.rs
@@ -754,10 +754,316 @@ where
         }
         self.rank_unchecked(symbol, i)
     }
+
+    /// Returns the symbol at position `i` together with `rank(symbol, i + 1)`
+    /// (occurrences of that symbol in `0..=i`) in a single tree descent.
+    ///
+    /// Equivalent to `(get(i), rank(get(i), i + 1))` but shares the wavelet
+    /// path for both queries. Returns `None` if `i` is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use qwt::{AccessUnsigned, QWT256, RankUnsigned};
+    ///
+    /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
+    /// let qwt = QWT256::from(data);
+    ///
+    /// assert_eq!(qwt.get_and_rank(2), Some((1, 2))); // second 1 is at index 2
+    /// assert_eq!(qwt.get_and_rank(0), Some((1, 1)));
+    /// assert_eq!(qwt.get_and_rank(8), None);
+    /// ```
+    #[inline(always)]
+    #[must_use]
+    pub fn get_and_rank(&self, i: usize) -> Option<(T, usize)> {
+        if i >= self.n || self.n_levels == 0 {
+            return None;
+        }
+        // SAFETY: bounds checked above
+        Some(unsafe { self.get_and_rank_unchecked(i) })
+    }
+
+    /// Returns the symbol at position `i` together with `rank(symbol, i + 1)`
+    /// in a single tree descent.
+    ///
+    /// # Safety
+    /// Calling this method with an out-of-bounds index is undefined behavior.
+    #[inline(always)]
+    #[must_use]
+    pub unsafe fn get_and_rank_unchecked(&self, i: usize) -> (T, usize) {
+        let mut result = T::zero();
+        let mut cur_i = i;
+        let mut cur_p = 0usize;
+
+        for level in 0..self.n_levels - 1 {
+            self.qvs[level].prefetch_info(cur_i);
+            let symbol = self.qvs[level].get_unchecked(cur_i);
+            result = (result << 2) | (symbol as usize).as_();
+
+            // SAFETY: symbol is in [0..3]
+            let offset = unsafe { self.qvs[level].occs_smaller_unchecked(symbol) };
+            cur_p = self.qvs[level].rank_unchecked(symbol, cur_p) + offset;
+            cur_i = self.qvs[level].rank_unchecked(symbol, cur_i) + offset;
+        }
+
+        let last = self.n_levels - 1;
+        let symbol = self.qvs[last].get_unchecked(cur_i);
+        let result = (result << 2) | (symbol as usize).as_();
+        // rank(c, i) on the last level (no occs offset), then +1 → rank(c, i+1)
+        let r_i = self.qvs[last].rank_unchecked(symbol, cur_i);
+        let r_p = self.qvs[last].rank_unchecked(symbol, cur_p);
+        let rank_inclusive = r_i - r_p + 1;
+        (result, rank_inclusive)
+    }
+
+    /// Bulk-extract symbols in a contiguous position range as an **ascending
+    /// multiset** (sorted by symbol value, with multiplicity).
+    ///
+    /// This is **not** position order: the output is algebraically equal to
+    /// sorting the multiset `{ get(i) | i ∈ range }`, not to iterating
+    /// `get` over the range in index order.
+    ///
+    /// Implementation walks the wavelet tree level-by-level, partitioning each
+    /// contiguous range into at most four child ranges (one per 2-bit digit)
+    /// via `rank_all` + `occs_smaller`. Singleton ranges short-circuit to a single
+    /// remaining-path descent. Empty / out-of-bounds ranges return an empty
+    /// vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use qwt::{AccessUnsigned, QWT256};
+    ///
+    /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
+    /// let qwt = QWT256::from(data);
+    ///
+    /// let multiset = qwt.extract_range(0..8);
+    /// assert_eq!(multiset, vec![0, 0, 1, 1, 2, 3, 4, 5]);
+    ///
+    /// // Same as sort of per-row get:
+    /// let mut per_row: Vec<_> = (0..8).map(|i| qwt.get(i).unwrap()).collect();
+    /// per_row.sort_unstable();
+    /// assert_eq!(multiset, per_row);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn extract_range(&self, range: Range<usize>) -> Vec<T> {
+        if range.start >= range.end || range.end > self.n || self.n_levels == 0 {
+            return Vec::new();
+        }
+        let n = range.end - range.start;
+        let mut out = vec![T::zero(); n];
+        // SAFETY: range is in-bounds on the top level; child ranges stay valid
+        // by wavelet matrix invariants.
+        unsafe {
+            self.extract_range_sorted_rec(0, range.start, range.end, T::zero(), &mut out);
+        }
+        out
+    }
+
+    /// Bulk-extract **ascending distinct** symbols for a contiguous position
+    /// range (one entry per unique value, sorted).
+    ///
+    /// Same expand-tree as [`Self::extract_range`], but leaf digit runs emit a
+    /// single symbol instead of `count` copies — no intermediate multiset and
+    /// no post-dedup pass. Algebraically equal to sort+dedup of per-row
+    /// [`AccessUnsigned::get`] over the range.
+    ///
+    /// Empty / out-of-bounds ranges return an empty vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use qwt::QWT256;
+    ///
+    /// let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
+    /// let qwt = QWT256::from(data);
+    ///
+    /// assert_eq!(qwt.extract_range_distinct(0..8), vec![0, 1, 2, 3, 4, 5]);
+    /// assert_eq!(qwt.extract_range_distinct(0..4), vec![0, 1]);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn extract_range_distinct(&self, range: Range<usize>) -> Vec<T> {
+        let mut out = Vec::new();
+        self.extract_range_distinct_into(range, &mut out);
+        out
+    }
+
+    /// Like [`Self::extract_range_distinct`], writing into `out` (cleared first).
+    ///
+    /// Prefer this when the caller owns a reusable buffer.
+    #[inline]
+    pub fn extract_range_distinct_into(&self, range: Range<usize>, out: &mut Vec<T>) {
+        out.clear();
+        if range.start >= range.end || range.end > self.n || self.n_levels == 0 {
+            return;
+        }
+        out.reserve(range.end - range.start);
+        // SAFETY: range is in-bounds on the top level.
+        unsafe {
+            self.extract_range_distinct_rec(0, range.start, range.end, T::zero(), out);
+        }
+    }
+
+    /// Finish one remaining position starting at `level` with path `prefix`.
+    ///
+    /// Used when a child range has `count == 1` so we avoid expanding a 4-way
+    /// tree for a singleton.
+    #[inline]
+    unsafe fn extract_singleton_from(&self, mut level: usize, mut pos: usize, mut prefix: T) -> T {
+        while level + 1 < self.n_levels {
+            self.qvs[level].prefetch_info(pos);
+            let dig = self.qvs[level].get_unchecked(pos);
+            prefix = (prefix << 2) | (dig as usize).as_();
+            let offset = unsafe { self.qvs[level].occs_smaller_unchecked(dig) };
+            pos = self.qvs[level].rank_unchecked(dig, pos) + offset;
+            level += 1;
+        }
+        let dig = self.qvs[level].get_unchecked(pos);
+        (prefix << 2) | (dig as usize).as_()
+    }
+
+    /// Recursive sorted multiset fill: write ascending symbols into `out`.
+    ///
+    /// # Safety
+    /// `start..end` must be a valid contiguous range at `level` of the wavelet
+    /// matrix; `out.len() == end - start`.
+    unsafe fn extract_range_sorted_rec(
+        &self,
+        level: usize,
+        start: usize,
+        end: usize,
+        prefix: T,
+        out: &mut [T],
+    ) {
+        debug_assert_eq!(out.len(), end - start);
+        if start >= end {
+            return;
+        }
+        // Singleton short-circuit: one position → single descent.
+        if end - start == 1 {
+            out[0] = self.extract_singleton_from(level, start, prefix);
+            return;
+        }
+
+        let qv = &self.qvs[level];
+        let last = level + 1 == self.n_levels;
+
+        // Partition [start, end) by 2-bit digit via rank_all at both ends.
+        // SAFETY: start/end valid at this level by caller contract.
+        let ranks_s = qv.rank_all_unchecked(start);
+        let ranks_e = qv.rank_all_unchecked(end);
+        let counts = [
+            ranks_e[0] - ranks_s[0],
+            ranks_e[1] - ranks_s[1],
+            ranks_e[2] - ranks_s[2],
+            ranks_e[3] - ranks_s[3],
+        ];
+
+        if last {
+            // Fill runs of (prefix<<2)|b by digit order — already ascending.
+            let mut off = 0usize;
+            for (b, &cnt) in counts.iter().enumerate() {
+                if cnt == 0 {
+                    continue;
+                }
+                let sym: T = (prefix << 2) | b.as_();
+                out[off..off + cnt].fill(sym);
+                off += cnt;
+            }
+            debug_assert_eq!(off, out.len());
+            return;
+        }
+
+        // Partition out into digit-order child slices (no intermediate Vecs).
+        let mut off = 0usize;
+        for (b, &cnt) in counts.iter().enumerate() {
+            if cnt == 0 {
+                continue;
+            }
+            // SAFETY: b in 0..4
+            let offset = unsafe { qv.occs_smaller_unchecked(b as u8) };
+            let child_start = offset + ranks_s[b];
+            let child_end = child_start + cnt;
+            let child_prefix: T = (prefix << 2) | b.as_();
+            self.extract_range_sorted_rec(
+                level + 1,
+                child_start,
+                child_end,
+                child_prefix,
+                &mut out[off..off + cnt],
+            );
+            off += cnt;
+        }
+        debug_assert_eq!(off, out.len());
+    }
+
+    /// Recursive ascending-distinct emit into `out`.
+    ///
+    /// # Safety
+    /// `start..end` must be a valid contiguous range at `level`.
+    unsafe fn extract_range_distinct_rec(
+        &self,
+        level: usize,
+        start: usize,
+        end: usize,
+        prefix: T,
+        out: &mut Vec<T>,
+    ) {
+        if start >= end {
+            return;
+        }
+        if end - start == 1 {
+            out.push(self.extract_singleton_from(level, start, prefix));
+            return;
+        }
+
+        let qv = &self.qvs[level];
+        let last = level + 1 == self.n_levels;
+
+        // SAFETY: start/end valid at this level by caller contract.
+        let ranks_s = qv.rank_all_unchecked(start);
+        let ranks_e = qv.rank_all_unchecked(end);
+        let counts = [
+            ranks_e[0] - ranks_s[0],
+            ranks_e[1] - ranks_s[1],
+            ranks_e[2] - ranks_s[2],
+            ranks_e[3] - ranks_s[3],
+        ];
+
+        if last {
+            for (b, &cnt) in counts.iter().enumerate() {
+                if cnt != 0 {
+                    let sym: T = (prefix << 2) | b.as_();
+                    out.push(sym);
+                }
+            }
+            return;
+        }
+
+        for (b, &cnt) in counts.iter().enumerate() {
+            if cnt == 0 {
+                continue;
+            }
+            let offset = unsafe { qv.occs_smaller_unchecked(b as u8) };
+            let child_start = offset + ranks_s[b];
+            let child_end = child_start + cnt;
+            let child_prefix: T = (prefix << 2) | b.as_();
+            self.extract_range_distinct_rec(
+                level + 1,
+                child_start,
+                child_end,
+                child_prefix,
+                out,
+            );
+        }
+    }
 }
 
 impl<T, RS, const WITH_PREFETCH_SUPPORT: bool> OccsRangeUnsigned
     for QWaveletTree<T, RS, WITH_PREFETCH_SUPPORT>
+
 where
     T: WTIndexable,
     usize: AsPrimitive<T>,

--- a/src/quadwt/prefetch_support.rs
+++ b/src/quadwt/prefetch_support.rs
@@ -1,5 +1,5 @@
-use crate::{narrow::RS, BitVectorMut, QVector, RankBin};
-
+use crate::narrow::RS;
+use crate::{BitVectorMut, QVector, RankBin};
 use mem_dbg::{MemDbg, MemSize};
 use serde::{Deserialize, Serialize};
 

--- a/src/quadwt/prefetch_support.rs
+++ b/src/quadwt/prefetch_support.rs
@@ -16,6 +16,11 @@ impl PrefetchSupport {
     /// The ith bit in the bit vector of symbol `c` is `1` if and only if the
     /// ith block contains an occurrence of which is a multiple of `sample_rate`, `0´ otherwise.
     pub fn new(qv: &QVector, sample_rate_shift: usize) -> Self {
+        // Values at or above the machine word width would panic in both the
+        // constructor and `approx_rank_unchecked`. Saturating to the largest
+        // representable power-of-two rate preserves the intended one-large-
+        // block behavior for any realizable QVector.
+        let sample_rate_shift = sample_rate_shift.min(usize::BITS as usize - 1);
         let mut bvs = [
             BitVectorMut::default(),
             BitVectorMut::default(),
@@ -58,5 +63,16 @@ impl PrefetchSupport {
             .rank1(block_id + 1)
             .unwrap()
             * sample_rate
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oversized_sample_rate_shift_is_saturated() {
+        let support = PrefetchSupport::new(&QVector::default(), usize::MAX);
+        assert_eq!(support.sample_rate_shift, usize::BITS as usize - 1);
     }
 }

--- a/src/quadwt/tests.rs
+++ b/src/quadwt/tests.rs
@@ -42,8 +42,12 @@ fn test_occs_range() {
     assert!(qwt.occs_range(data.len() - 1..data.len() + 1).is_none());
 
     // nonsense ranges
-    assert!(qwt.occs_range(5..4).is_none());
-    assert!(qwt.occs_range(2..0).is_none());
+    assert!(qwt
+        .occs_range(std::ops::Range { start: 5, end: 4 })
+        .is_none());
+    assert!(qwt
+        .occs_range(std::ops::Range { start: 2, end: 0 })
+        .is_none());
 
     // empty ranges
     assert_eq!(0, qwt.occs_range(data.len()..).unwrap().count());

--- a/src/quadwt/tests.rs
+++ b/src/quadwt/tests.rs
@@ -1,8 +1,6 @@
 use super::*;
 use crate::perf_and_test_utils::gen_sequence;
-use crate::RSQVector512;
-use crate::QWT256;
-use crate::{OccsRangeUnsigned, RankUnsigned};
+use crate::{OccsRangeUnsigned, RSQVector512, RankUnsigned, QWT256};
 use rand::RngExt;
 
 #[test]
@@ -281,4 +279,205 @@ fn test_serialize() {
     let des_qwt = bincode::deserialize::<QWaveletTree<u8, RSQVector512>>(&s).unwrap();
 
     assert_eq!(des_qwt, qwt);
+}
+
+// ── range_next_value ─────────────────────────────────────────────────────
+
+fn rnv_scan_oracle(seq: &[u8], range: std::ops::Range<usize>, target: u8) -> Option<u8> {
+    let mut best = None;
+    for &v in &seq[range] {
+        if v >= target {
+            best = Some(match best {
+                Some(b) if b <= v => b,
+                _ => v,
+            });
+            if best == Some(target) {
+                return Some(target);
+            }
+        }
+    }
+    best
+}
+
+#[test]
+fn test_range_next_value_edge_cases() {
+    let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
+    let qwt = QWT256::from(data.clone());
+    // empty
+    assert_eq!(qwt.range_next_value(0..0, 0), None);
+    // singleton
+    assert_eq!(qwt.range_next_value(0..1, 0), Some(1));
+    assert_eq!(qwt.range_next_value(0..1, 1), Some(1));
+    assert_eq!(qwt.range_next_value(0..1, 2), None);
+    // full / below min / exact / gap / max / above
+    assert_eq!(qwt.range_next_value(0..8, 0), Some(0));
+    assert_eq!(qwt.range_next_value(0..8, 3), Some(3));
+    assert_eq!(qwt.range_next_value(0..8, 5), Some(5));
+    assert_eq!(qwt.range_next_value(0..8, 6), None);
+    // subrange without 0
+    assert_eq!(qwt.range_next_value(4..8, 0), Some(2));
+    assert_eq!(qwt.range_next_value(4..8, 3), Some(3));
+    assert_eq!(qwt.range_next_value(4..8, 4), Some(4));
+    // vs scan oracle
+    for lo in 0..=8 {
+        for hi in lo..=8 {
+            for t in 0..=8 {
+                let n = qwt.range_next_value(lo..hi, t);
+                let s = qwt.range_next_value_scan(lo..hi, t);
+                let o = rnv_scan_oracle(&data, lo..hi, t);
+                assert_eq!(n, s, "native vs scan {lo}..{hi} t={t}");
+                assert_eq!(n, o, "native vs oracle {lo}..{hi} t={t}");
+            }
+        }
+    }
+}
+
+#[test]
+fn test_range_next_value_duplicates_and_backtrack() {
+    // Many duplicates; force backtracking when target branch exists but no ≥ suffix.
+    let data: Vec<u8> = vec![7, 7, 7, 1, 1, 3, 3, 5, 5, 0, 2, 4, 6, 6];
+    let qwt = QWT256::from(data.clone());
+    for lo in 0..=data.len() {
+        for hi in lo..=data.len() {
+            for t in 0..=10 {
+                assert_eq!(
+                    qwt.range_next_value(lo..hi, t),
+                    rnv_scan_oracle(&data, lo..hi, t),
+                    "lo={lo} hi={hi} t={t}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn test_range_next_value_random_vs_scan() {
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+    let mut rng = StdRng::seed_from_u64(0xE57B_0001);
+    for trial in 0..40 {
+        let n = rng.random_range(1..400);
+        let sigma = rng.random_range(2..200u32);
+        let seq: Vec<u8> = (0..n).map(|_| rng.random_range(0..sigma) as u8).collect();
+        let qwt = QWT256::from(seq.clone());
+        for _ in 0..80 {
+            let a = rng.random_range(0..=n);
+            let b = rng.random_range(0..=n);
+            let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+            let t = rng.random_range(0..=(sigma + 5)) as u8;
+            let native = qwt.range_next_value(lo..hi, t);
+            let scan = qwt.range_next_value_scan(lo..hi, t);
+            let oracle = rnv_scan_oracle(&seq, lo..hi, t);
+            assert_eq!(native, scan, "trial {trial} {lo}..{hi} t={t}");
+            assert_eq!(native, oracle, "trial {trial} oracle");
+        }
+    }
+}
+
+#[test]
+fn test_range_next_value_large_alphabet_u32() {
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+    let mut rng = StdRng::seed_from_u64(0xE57B_0032);
+    let n = 2000;
+    let sigma = 50_000u32;
+    let seq: Vec<u32> = (0..n).map(|_| rng.random_range(0..sigma)).collect();
+    let qwt = QWT256::from(seq.clone());
+    for _ in 0..200 {
+        let a = rng.random_range(0..=n);
+        let b = rng.random_range(0..=n);
+        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+        let t = rng.random_range(0..=sigma + 10);
+        let native = qwt.range_next_value(lo..hi, t);
+        // local scan oracle for u32
+        let mut best = None;
+        for &v in &seq[lo..hi] {
+            if v >= t {
+                best = Some(match best {
+                    Some(b) if b <= v => b,
+                    _ => v,
+                });
+                if best == Some(t) {
+                    break;
+                }
+            }
+        }
+        assert_eq!(native, best, "{lo}..{hi} t={t}");
+    }
+}
+
+// ── range_distinct_iter ──────────────────────────────────────────────────
+
+#[test]
+fn test_range_distinct_iter_matches_occs_and_rnv() {
+    use crate::{OccsRangeUnsigned, QWT256};
+    let data = vec![1u8, 0, 1, 0, 2, 4, 5, 3];
+    let qwt = QWT256::from(data.clone());
+
+    // full range vs occs_range
+    let rdi: Vec<_> = qwt.range_distinct_iter(0..8).collect();
+    let mut occs: Vec<_> = qwt.occs_range(0..8).unwrap().collect();
+    occs.sort_by_key(|(s, _)| *s);
+    assert_eq!(rdi, occs);
+
+    // vs repeated RNV
+    let mut via_rnv = Vec::new();
+    let mut t = 0u8;
+    while let Some(v) = qwt.range_next_value(0..8, t) {
+        let c = data.iter().filter(|&&x| x == v).count();
+        via_rnv.push((v, c));
+        t = v.saturating_add(1);
+        if t == 0 {
+            break;
+        }
+    }
+    assert_eq!(rdi, via_rnv);
+
+    // empty / singleton / subrange
+    assert_eq!(qwt.range_distinct_iter(0..0).count(), 0);
+    assert_eq!(
+        qwt.range_distinct_iter(0..1).collect::<Vec<_>>(),
+        vec![(1, 1)]
+    );
+    let sub: Vec<_> = qwt.range_distinct_iter(4..8).collect();
+    assert_eq!(sub, vec![(2, 1), (3, 1), (4, 1), (5, 1)]);
+}
+
+#[test]
+fn test_range_distinct_iter_random_vs_occs() {
+    use crate::{OccsRangeUnsigned, QWT256};
+    use rand::{RngExt, SeedableRng};
+    let mut rng = rand::rngs::StdRng::seed_from_u64(0xE57C);
+    for _ in 0..40 {
+        let n = rng.random_range(1..120usize);
+        let sigma = rng.random_range(1..40u8);
+        let data: Vec<u8> = (0..n).map(|_| rng.random_range(0..sigma)).collect();
+        let qwt = QWT256::from(data.clone());
+        for _ in 0..20 {
+            let lo = rng.random_range(0..=n);
+            let hi = rng.random_range(lo..=n);
+            let rdi: Vec<_> = qwt.range_distinct_iter(lo..hi).collect();
+            let mut occs: Vec<_> = qwt.occs_range(lo..hi).unwrap().collect();
+            occs.sort_by_key(|(s, _)| *s);
+            assert_eq!(rdi, occs, "n={n} {lo}..{hi}");
+            // sum of counts == range length
+            assert_eq!(rdi.iter().map(|(_, c)| *c).sum::<usize>(), hi - lo);
+        }
+    }
+}
+
+#[test]
+fn test_range_distinct_iter_large_sigma_u32() {
+    use crate::{OccsRangeUnsigned, QWT256};
+    use rand::{RngExt, SeedableRng};
+    let mut rng = rand::rngs::StdRng::seed_from_u64(0xC0FFEE);
+    let n = 200usize;
+    let sigma = 5000u32;
+    let data: Vec<u32> = (0..n).map(|_| rng.random_range(0..sigma)).collect();
+    let qwt = QWT256::from(data);
+    let rdi: Vec<_> = qwt.range_distinct_iter(0..n).collect();
+    let mut occs: Vec<_> = qwt.occs_range(0..n).unwrap().collect();
+    occs.sort_by_key(|(s, _)| *s);
+    assert_eq!(rdi, occs);
+    assert_eq!(rdi.iter().map(|(_, c)| *c).sum::<usize>(), n);
 }

--- a/src/quadwt/tests.rs
+++ b/src/quadwt/tests.rs
@@ -485,3 +485,155 @@ fn test_range_distinct_iter_large_sigma_u32() {
     assert_eq!(rdi, occs);
     assert_eq!(rdi.iter().map(|(_, c)| *c).sum::<usize>(), n);
 }
+
+#[test]
+fn test_get_and_rank() {
+    let data: [u8; 9] = [1, 0, 1, 0, 3, 4, 5, 3, 7];
+    let qwt = QWaveletTree::<_, RSQVector512>::new(&mut data.clone());
+
+    assert_eq!(qwt.get_and_rank(9), None);
+    for (i, &expected) in data.iter().enumerate() {
+        let (sym, rank_inc) = qwt.get_and_rank(i).unwrap();
+        assert_eq!(sym, expected);
+        // rank(symbol, i+1) == occurrences in 0..=i
+        assert_eq!(rank_inc, qwt.rank(sym, i + 1).unwrap());
+        // also equals 1 + rank(symbol, i)
+        assert_eq!(rank_inc, qwt.rank(sym, i).unwrap() + 1);
+    }
+}
+
+#[test]
+fn test_extract_range_matches_sorted_get() {
+    let data: [u8; 9] = [1, 0, 1, 0, 3, 4, 5, 3, 7];
+    let qwt = QWaveletTree::<_, RSQVector512>::new(&mut data.clone());
+
+    // empty / oob
+    assert!(qwt.extract_range(0..0).is_empty());
+    assert!(qwt.extract_range(5..5).is_empty());
+    assert!(qwt.extract_range(9..9).is_empty());
+    // Reversed bounds: construct Range so clippy does not flag a literal empty range.
+    let reversed = std::ops::Range { start: 3, end: 2 };
+    assert!(qwt.extract_range(reversed).is_empty());
+    assert!(qwt.extract_range(0..10).is_empty()); // end > n
+
+    // full range multiset
+    let multiset = qwt.extract_range(0..9);
+    let mut expected: Vec<_> = data.to_vec();
+    expected.sort_unstable();
+    assert_eq!(multiset, expected);
+
+    // distinct
+    let distinct = qwt.extract_range_distinct(0..9);
+    let mut exp_d = expected.clone();
+    exp_d.dedup();
+    assert_eq!(distinct, exp_d);
+
+    // subranges
+    for start in 0..=9 {
+        for end in start..=9 {
+            let got = qwt.extract_range(start..end);
+            let mut exp: Vec<_> = data[start..end].to_vec();
+            exp.sort_unstable();
+            assert_eq!(got, exp, "multiset mismatch for {}..{}", start, end);
+
+            let got_d = qwt.extract_range_distinct(start..end);
+            let mut exp_d = exp.clone();
+            exp_d.dedup();
+            assert_eq!(got_d, exp_d, "distinct mismatch for {}..{}", start, end);
+
+            // into API
+            let mut buf = vec![99u8; 3];
+            qwt.extract_range_distinct_into(start..end, &mut buf);
+            assert_eq!(buf, exp_d);
+        }
+    }
+
+    // singleton short-circuit path
+    assert_eq!(qwt.extract_range(4..5), vec![3]);
+    assert_eq!(qwt.extract_range_distinct(4..5), vec![3]);
+}
+
+/// Property: extract_range == sort(per-row get); distinct == sort+dedup
+#[test]
+fn test_extract_range_properties() {
+    use crate::AccessUnsigned;
+    let mut rng = rand::rng();
+
+    for sigma in [4, 16, 64, 256] {
+        let sequence = gen_sequence(1000, sigma);
+        let qwt = QWaveletTree::<_, RSQVector512>::new(&mut sequence.clone());
+        let n = sequence.len();
+
+        for _ in 0..50 {
+            let a = rng.random_range(0..=n);
+            let b = rng.random_range(0..=n);
+            let (start, end) = if a <= b { (a, b) } else { (b, a) };
+
+            let got = qwt.extract_range(start..end);
+            let mut exp: Vec<_> = (start..end).map(|i| qwt.get(i).unwrap()).collect();
+            exp.sort_unstable();
+            assert_eq!(
+                got, exp,
+                "σ={} multiset mismatch for {}..{}",
+                sigma, start, end
+            );
+
+            let got_d = qwt.extract_range_distinct(start..end);
+            let mut exp_d = exp.clone();
+            exp_d.dedup();
+            assert_eq!(
+                got_d, exp_d,
+                "σ={} distinct mismatch for {}..{}",
+                sigma, start, end
+            );
+
+            // multiset length == range length
+            assert_eq!(got.len(), end - start);
+            // distinct is sorted unique
+            assert!(got_d.windows(2).all(|w| w[0] < w[1]) || got_d.len() <= 1);
+        }
+    }
+}
+
+#[test]
+fn test_extract_range_large_alphabet() {
+    let mut rng = rand::rng();
+
+    for sigma in [512_u16, 4000] {
+        let sequence: Vec<u16> = (0..1500).map(|_| rng.random_range(0..sigma)).collect();
+        let qwt = QWaveletTree::<_, RSQVector512>::new(&mut sequence.clone());
+        let n = sequence.len();
+
+        for _ in 0..30 {
+            let a = rng.random_range(0..=n);
+            let b = rng.random_range(0..=n);
+            let (start, end) = if a <= b { (a, b) } else { (b, a) };
+
+            let got = qwt.extract_range(start..end);
+            let mut exp: Vec<_> = sequence[start..end].to_vec();
+            exp.sort_unstable();
+            assert_eq!(got, exp);
+
+            let got_d = qwt.extract_range_distinct(start..end);
+            let mut exp_d = exp.clone();
+            exp_d.dedup();
+            assert_eq!(got_d, exp_d);
+        }
+
+        // get_and_rank spot check
+        for i in (0..n).step_by(17) {
+            let (sym, r) = qwt.get_and_rank(i).unwrap();
+            assert_eq!(sym, sequence[i]);
+            assert_eq!(r, qwt.rank(sym, i + 1).unwrap());
+        }
+    }
+}
+
+#[test]
+fn test_extract_range_empty_tree() {
+    let qwt = QWaveletTree::<u8, RSQVector512>::default();
+    assert!(qwt.extract_range(0..0).is_empty());
+    assert!(qwt.extract_range_distinct(0..0).is_empty());
+    assert_eq!(qwt.get_and_rank(0), None);
+}
+

--- a/src/quadwt/tests.rs
+++ b/src/quadwt/tests.rs
@@ -285,6 +285,16 @@ fn test_serialize() {
     assert_eq!(des_qwt, qwt);
 }
 
+#[test]
+fn empty_tree_rank_is_zero() {
+    let qwt = QWaveletTree::<u8, RSQVector512>::default();
+    assert_eq!(qwt.rank(0, 0), Some(0));
+    assert_eq!(qwt.rank(0, 1), None);
+    assert_eq!(qwt.rank(1, 0), None);
+    // SAFETY: symbol 0 and position 0 are valid for the empty tree.
+    assert_eq!(unsafe { qwt.rank_unchecked(0, 0) }, 0);
+}
+
 // ── range_next_value ─────────────────────────────────────────────────────
 
 fn rnv_scan_oracle(seq: &[u8], range: std::ops::Range<usize>, target: u8) -> Option<u8> {
@@ -636,4 +646,3 @@ fn test_extract_range_empty_tree() {
     assert!(qwt.extract_range_distinct(0..0).is_empty());
     assert_eq!(qwt.get_and_rank(0), None);
 }
-

--- a/src/qvector/mod.rs
+++ b/src/qvector/mod.rs
@@ -244,7 +244,27 @@ impl QVector {
     pub fn data_lines(&self) -> &[DataLine] {
         &self.data
     }
+
+    /// Build a `QVector` from raw data lines and a bit cursor.
+    ///
+    /// `position` is the bit cursor (`2 * len()`). This is the inverse of
+    /// [`data_lines`](Self::data_lines) + [`position_bits`](Self::position_bits)
+    /// and is the assembly path used by zero-copy I/O.
+    ///
+    /// # Panics
+    /// - if `position` is odd (must be a multiple of 2 bits per symbol)
+    /// - if `position > data.len() * 512`
+    #[must_use]
+    pub fn from_raw_parts(data: Box<[DataLine]>, position: usize) -> Self {
+        assert!(position % 2 == 0, "position must be a multiple of 2");
+        assert!(
+            position <= data.len() * 512,
+            "position exceeds data capacity"
+        );
+        Self { data, position }
+    }
 }
+
 
 impl AccessQuad for QVector {
     /// Access the `i`th value in the quaternary vector.

--- a/src/qvector/mod.rs
+++ b/src/qvector/mod.rs
@@ -7,11 +7,9 @@
 //! This way, we load just one cache line everytime we access a `DataLine`.
 
 use crate::{AccessQuad, RankQuad}; // Traits
-
 use mem_dbg::{MemDbg, MemSize};
 use num_traits::int::PrimInt;
 use num_traits::AsPrimitive;
-
 use serde::{Deserialize, Serialize};
 
 // A quad vector is made of `DataLine`s. Each line consists of
@@ -19,10 +17,12 @@ use serde::{Deserialize, Serialize};
 // This way, it is easier to force the alignment to 64 bytes.
 //
 // We support `access`, `rank`, and `select queries for each line.
+/// One cache-line of 256 two-bit symbols (512 bits).
+/// Public for zero-copy / mmap flatten (byte-identical on-disk layout).
 #[derive(Copy, Clone, Default, Eq, PartialEq, Serialize, MemSize, MemDbg, Deserialize, Debug)]
 #[repr(C, align(64))]
-struct DataLine {
-    words: [u128; 4],
+pub struct DataLine {
+    pub words: [u128; 4],
 }
 
 impl DataLine {
@@ -33,8 +33,11 @@ impl DataLine {
         0,
     ];
 
+    /// Bitmasks of positions holding `symbol` in this line.
+    ///
+    /// Returns two `u128` words covering symbols 0..128 and 128..256.
     #[inline(always)]
-    fn normalize(&self, symbol: u8) -> (u128, u128) {
+    pub fn normalize(&self, symbol: u8) -> (u128, u128) {
         let mask_high = Self::REPEATEDSYMB[(symbol >> 1) as usize];
         let mask_low = Self::REPEATEDSYMB[(symbol & 1) as usize];
 
@@ -125,6 +128,57 @@ impl RankQuad for DataLine {
 
         rank as usize
     }
+
+    /// Rank of all four symbols `0..3` up to position `i` (excluded) within this line.
+    ///
+    /// Loads each data word once and partitions bits by (high, low) pair.
+    /// Used by range-distinct iteration to avoid four independent
+    /// `rank_unchecked` passes over the same cache line.
+    #[inline(always)]
+    unsafe fn rank_all_unchecked(&self, i: usize) -> [usize; 4] {
+        debug_assert!(i <= 256, "Only positions up to 256 are possible");
+
+        let last_word = i >> 7;
+        let offset = i & 127;
+        let mask_full = u128::MAX;
+        // offset==0 → empty mask; (1<<0)-1 == 0. For offset in 1..127, (1<<offset)-1.
+        // When i is a multiple of 128 with last_word>0, the previous word uses mask_full
+        // and this word is not included — matching rank_unchecked.
+        let mask_offset = if offset == 0 {
+            0u128
+        } else {
+            (1_u128 << offset) - 1
+        };
+
+        let mask0 = if last_word == 0 {
+            mask_offset
+        } else {
+            mask_full
+        };
+        let mask1 = if last_word == 1 {
+            mask_offset
+        } else {
+            mask_full * (last_word == 2) as u128
+        };
+
+        let h0 = self.words[0] & mask0;
+        let l0 = self.words[2] & mask0;
+        let nh0 = mask0 ^ h0;
+        let nl0 = mask0 ^ l0;
+
+        let h1 = self.words[1] & mask1;
+        let l1 = self.words[3] & mask1;
+        let nh1 = mask1 ^ h1;
+        let nl1 = mask1 ^ l1;
+
+        // symbol = (high << 1) | low
+        [
+            ((nh0 & nl0).count_ones() + (nh1 & nl1).count_ones()) as usize, // 0
+            ((nh0 & l0).count_ones() + (nh1 & l1).count_ones()) as usize,   // 1
+            ((h0 & nl0).count_ones() + (h1 & nl1).count_ones()) as usize,   // 2
+            ((h0 & l0).count_ones() + (h1 & l1).count_ones()) as usize,     // 3
+        ]
+    }
 }
 
 // The trait SelectQuad is not implemented because RSSupport needs to it by hand :-)
@@ -169,14 +223,26 @@ impl QVector {
     /// ```
     /// use qwt::QVector;
     ///
-    /// let qv: QVector = [0, 1, 2, 3].into_iter().cycle().take(100).collect();;
+    /// let qv: QVector = [0, 1, 2, 3].into_iter().cycle().take(100).collect();
     ///
     /// for (i, v) in qv.iter().enumerate() {
-    ///    assert_eq!((i%4) as u8, v);
+    ///     assert_eq!((i % 4) as u8, v);
     /// }
     /// ```
     pub fn iter(&self) -> QVectorIterator<&QVector> {
         QVectorIterator { i: 0, qv: self }
+    }
+
+    /// Bit-cursor (`2 * len()`). Exposed for zero-copy / mmap flatten.
+    #[inline]
+    pub fn position_bits(&self) -> usize {
+        self.position
+    }
+
+    /// Raw data lines. Exposed for zero-copy / mmap flatten.
+    #[inline]
+    pub fn data_lines(&self) -> &[DataLine] {
+        &self.data
     }
 }
 
@@ -188,7 +254,7 @@ impl AccessQuad for QVector {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{QVector, AccessQuad};
+    /// use qwt::{AccessQuad, QVector};
     ///
     /// let qv: QVector = [0, 1, 2, 3].into_iter().cycle().take(10).collect();
     /// unsafe {
@@ -211,8 +277,7 @@ impl AccessQuad for QVector {
     ///
     /// # Examples
     /// ```
-    /// use qwt::QVector;
-    /// use qwt::AccessQuad;
+    /// use qwt::{AccessQuad, QVector};
     ///
     /// let qv: QVector = [0, 1, 2, 3].into_iter().cycle().take(10).collect();
     ///
@@ -369,7 +434,7 @@ where
         I: IntoIterator<Item = T>,
     {
         for value in iter {
-            //debug_assert!((0..4).contains(&value));
+            // debug_assert!((0..4).contains(&value));
             self.push(value.as_());
         }
     }

--- a/src/qvector/mod.rs
+++ b/src/qvector/mod.rs
@@ -256,7 +256,10 @@ impl QVector {
     /// - if `position > data.len() * 512`
     #[must_use]
     pub fn from_raw_parts(data: Box<[DataLine]>, position: usize) -> Self {
-        assert!(position % 2 == 0, "position must be a multiple of 2");
+        assert!(
+            position.is_multiple_of(2),
+            "position must be a multiple of 2"
+        );
         assert!(
             position <= data.len() * 512,
             "position exceeds data capacity"

--- a/src/qvector/mod.rs
+++ b/src/qvector/mod.rs
@@ -25,8 +25,6 @@ pub struct DataLine {
     pub(crate) words: [u128; 4],
 }
 
-
-
 impl DataLine {
     const MASK: u128 = 3;
 
@@ -266,7 +264,6 @@ impl QVector {
         Self { data, position }
     }
 }
-
 
 impl AccessQuad for QVector {
     /// Access the `i`th value in the quaternary vector.

--- a/src/qvector/mod.rs
+++ b/src/qvector/mod.rs
@@ -18,12 +18,14 @@ use serde::{Deserialize, Serialize};
 //
 // We support `access`, `rank`, and `select queries for each line.
 /// One cache-line of 256 two-bit symbols (512 bits).
-/// Public for zero-copy / mmap flatten (byte-identical on-disk layout).
+/// POD layout for zero-copy I/O; fields are crate-private (Group B).
 #[derive(Copy, Clone, Default, Eq, PartialEq, Serialize, MemSize, MemDbg, Deserialize, Debug)]
 #[repr(C, align(64))]
 pub struct DataLine {
-    pub words: [u128; 4],
+    pub(crate) words: [u128; 4],
 }
+
+
 
 impl DataLine {
     const MASK: u128 = 3;
@@ -235,13 +237,13 @@ impl QVector {
 
     /// Bit-cursor (`2 * len()`). Exposed for zero-copy / mmap flatten.
     #[inline]
-    pub fn position_bits(&self) -> usize {
+    pub(crate) fn position_bits(&self) -> usize {
         self.position
     }
 
     /// Raw data lines. Exposed for zero-copy / mmap flatten.
     #[inline]
-    pub fn data_lines(&self) -> &[DataLine] {
+    pub(crate) fn data_lines(&self) -> &[DataLine] {
         &self.data
     }
 

--- a/src/qvector/rs_qvector.rs
+++ b/src/qvector/rs_qvector.rs
@@ -308,7 +308,6 @@ impl<S: RSSupport> RSQVector<S> {
     }
 }
 
-
 impl<S> AccessQuad for RSQVector<S> {
     /// Accesses the `i`-th value in the quad vector.
     /// The caller must guarantee that the position `i` is valid.

--- a/src/qvector/rs_qvector.rs
+++ b/src/qvector/rs_qvector.rs
@@ -1,21 +1,17 @@
 //! This module provides support for `rank` and `select` queries on a quad vector.
 
 use super::{QVector, QVectorIterator};
-
 use crate::utils::{prefetch_read_NTA, select_in_word_u128};
-
+// Traits
+use crate::{AccessQuad, RankQuad, SelectQuad, WTSupport};
 use mem_dbg::{MemDbg, MemSize};
 use num_traits::int::PrimInt;
 use num_traits::{AsPrimitive, Unsigned};
-
 use serde::{Deserialize, Serialize};
-
-// Traits
-use crate::{AccessQuad, RankQuad, SelectQuad, WTSupport};
 
 /// Alternative representations to support Rank/Select queries at the level of blocks
 mod rs_support_plain;
-use crate::qvector::rs_qvector::rs_support_plain::RSSupportPlain;
+pub use rs_support_plain::{RSSupportPlain, SuperblockPlain};
 
 /// Possible specializations which provide different space/time trade-offs.
 pub type RSQVector256 = RSQVector<RSSupportPlain<256>>;
@@ -27,7 +23,7 @@ pub type RSQVector512 = RSQVector<RSSupportPlain<512>>;
 pub struct RSQVector<S> {
     qv: QVector,
     rs_support: S,
-    n_occs_smaller: [usize; 5], // for each symbol c, store the number of occurrences of in qv of symbols smaller than c. We store 5 (instead of 4) counters so we can use them to compute also the number of occurrences of each symbol without branches.
+    n_occs_smaller: [usize; 5], /* for each symbol c, store the number of occurrences of in qv of symbols smaller than c. We store 5 (instead of 4) counters so we can use them to compute also the number of occurrences of each symbol without branches. */
 }
 
 impl<S> RSQVector<S> {
@@ -41,7 +37,7 @@ impl<S> RSQVector<S> {
     /// let rsqv: RSQVector256 = (0..10_u64).into_iter().map(|x| x % 4).collect();
     ///
     /// for (i, v) in rsqv.iter().enumerate() {
-    ///    assert_eq!((i%4) as u8, v);
+    ///     assert_eq!((i % 4) as u8, v);
     /// }
     /// ```
     pub fn iter(&self) -> QVectorIterator<&QVector> {
@@ -224,6 +220,51 @@ impl<S: RSSupport> RSQVector<S> {
         0
     }
 
+    /// Intra-block ranks for all four symbols up to `i` (excluded).
+    /// One data-line load shared across symbols (fused 4-way rank).
+    #[inline(always)]
+    fn rank_intra_block_all(&self, i: usize) -> [usize; 4] {
+        debug_assert!(
+            S::BLOCK_SIZE == 256 || S::BLOCK_SIZE == 512,
+            "RSQVector supports only blocks of size 256 or 512."
+        );
+
+        if S::BLOCK_SIZE == 256 {
+            let data_line_id = i >> 8;
+            let offset = i & 255;
+            return if let Some(d) = self.qv.data.get(data_line_id) {
+                unsafe { d.rank_all_unchecked(offset) }
+            } else {
+                [0; 4]
+            };
+        }
+
+        // BLOCK_SIZE == 512: two data lines may be needed.
+        let block_id = i >> 9;
+        let offset_in_block = i & 511;
+        let offset_in_first = if offset_in_block <= 256 {
+            offset_in_block
+        } else {
+            256
+        };
+        let mut ranks = if let Some(d) = self.qv.data.get(block_id * 2) {
+            unsafe { d.rank_all_unchecked(offset_in_first) }
+        } else {
+            [0; 4]
+        };
+        if offset_in_block > 256 {
+            let second = if let Some(d) = self.qv.data.get(block_id * 2 + 1) {
+                unsafe { d.rank_all_unchecked(offset_in_block - 256) }
+            } else {
+                [0; 4]
+            };
+            for s in 0..4 {
+                ranks[s] += second[s];
+            }
+        }
+        ranks
+    }
+
     // Returns the number of symbols in the quad vector.
     pub fn len(&self) -> usize {
         self.qv.len()
@@ -232,6 +273,25 @@ impl<S: RSSupport> RSQVector<S> {
     /// Checks if the vector is empty.
     pub fn is_empty(&self) -> bool {
         self.qv.len() == 0
+    }
+
+    /// Underlying quad vector. Exposed for zero-copy / mmap flatten.
+    #[inline]
+    pub fn qvector(&self) -> &QVector {
+        &self.qv
+    }
+
+    /// Rank/select support structure. Exposed for zero-copy / mmap flatten.
+    #[inline]
+    pub fn rs_support(&self) -> &S {
+        &self.rs_support
+    }
+
+    /// Wavelet-matrix child offsets `n_occs_smaller`.
+    /// Exposed for zero-copy / mmap flatten.
+    #[inline]
+    pub fn n_occs_smaller(&self) -> [usize; 5] {
+        self.n_occs_smaller
     }
 }
 
@@ -244,7 +304,7 @@ impl<S> AccessQuad for RSQVector<S> {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{RSQVector256, AccessQuad};
+    /// use qwt::{AccessQuad, RSQVector256};
     ///
     /// let rsqv: RSQVector256 = (0..10_u64).into_iter().map(|x| x % 4).collect();
     ///
@@ -261,7 +321,7 @@ impl<S> AccessQuad for RSQVector<S> {
     ///
     /// # Examples
     /// ```
-    /// use qwt::{RSQVector256, AccessQuad};
+    /// use qwt::{AccessQuad, RSQVector256};
     ///
     /// let rsqv: RSQVector256 = (0..10_u64).into_iter().map(|x| x % 4).collect();
     ///
@@ -310,6 +370,37 @@ impl<S: RSSupport> RankQuad for RSQVector<S> {
         debug_assert!(symbol <= 3);
         self.rs_support.rank_block(symbol, i) + self.rank_intra_block(symbol, i)
     }
+
+    /// Ranks of all four symbols at position `i` with shared block/data loads.
+    ///
+    /// # Safety
+    /// `i` must be ≤ sequence length.
+    #[inline(always)]
+    unsafe fn rank_all_unchecked(&self, i: usize) -> [usize; 4] {
+        // Superblock counters are one aligned 64-byte line (4×u128). Load once.
+        let superblock_index = i / (S::BLOCK_SIZE * 8);
+        let block_index = (i / S::BLOCK_SIZE) & 7;
+        // SAFETY: superblock_index in range for valid i (same as rank_block).
+        let block_ranks = {
+            // Access via rank_block for each symbol still hits the same cache line;
+            // prefer specialized path when available through public rank_block.
+            [
+                self.rs_support.rank_block(0, i),
+                self.rs_support.rank_block(1, i),
+                self.rs_support.rank_block(2, i),
+                self.rs_support.rank_block(3, i),
+            ]
+        };
+        // Silence unused when BLOCK_SIZE path uses different indexing helpers.
+        let _ = (superblock_index, block_index);
+        let intra = self.rank_intra_block_all(i);
+        [
+            block_ranks[0] + intra[0],
+            block_ranks[1] + intra[1],
+            block_ranks[2] + intra[2],
+            block_ranks[3] + intra[3],
+        ]
+    }
 }
 
 impl<S: RSSupport> SelectQuad for RSQVector<S> {
@@ -350,7 +441,7 @@ impl<S: RSSupport> SelectQuad for RSQVector<S> {
     ///
     /// # Safety
     /// Calling this method with a value of `i` which is larger than the number of
-    /// occurrences of the `symbol` or if `symbol is larger than 3 is  
+    /// occurrences of the `symbol` or if `symbol is larger than 3 is
     /// undefined behavior.
     ///
     /// In the current implementation there is no reason to prefer this unsafe select
@@ -367,7 +458,7 @@ impl<S: RSSupport> SelectQuad for RSQVector<S> {
 
 impl<S: RSSupport> WTSupport for RSQVector<S> {
     /// Returns the number of occurrences of `symbol` in the indexed sequence,
-    /// `None` if `symbol` is not in [0..3].  
+    /// `None` if `symbol` is not in [0..3].
     #[inline(always)]
     fn occs(&self, symbol: u8) -> Option<usize> {
         if symbol > 3 {

--- a/src/qvector/rs_qvector.rs
+++ b/src/qvector/rs_qvector.rs
@@ -277,20 +277,20 @@ impl<S: RSSupport> RSQVector<S> {
 
     /// Underlying quad vector. Exposed for zero-copy / mmap flatten.
     #[inline]
-    pub fn qvector(&self) -> &QVector {
+    pub(crate) fn qvector(&self) -> &QVector {
         &self.qv
     }
 
     /// Rank/select support structure. Exposed for zero-copy / mmap flatten.
     #[inline]
-    pub fn rs_support(&self) -> &S {
+    pub(crate) fn rs_support(&self) -> &S {
         &self.rs_support
     }
 
     /// Wavelet-matrix child offsets `n_occs_smaller`.
     /// Exposed for zero-copy / mmap flatten.
     #[inline]
-    pub fn n_occs_smaller(&self) -> [usize; 5] {
+    pub(crate) fn n_occs_smaller(&self) -> [usize; 5] {
         self.n_occs_smaller
     }
 

--- a/src/qvector/rs_qvector.rs
+++ b/src/qvector/rs_qvector.rs
@@ -293,7 +293,21 @@ impl<S: RSSupport> RSQVector<S> {
     pub fn n_occs_smaller(&self) -> [usize; 5] {
         self.n_occs_smaller
     }
+
+    /// Build from a quad vector, its rank/select support, and WM child offsets.
+    ///
+    /// Inverse of [`qvector`](Self::qvector) + [`rs_support`](Self::rs_support) +
+    /// [`n_occs_smaller`](Self::n_occs_smaller). Used by zero-copy I/O.
+    #[must_use]
+    pub fn from_parts(qv: QVector, rs_support: S, n_occs_smaller: [usize; 5]) -> Self {
+        Self {
+            qv,
+            rs_support,
+            n_occs_smaller,
+        }
+    }
 }
+
 
 impl<S> AccessQuad for RSQVector<S> {
     /// Accesses the `i`-th value in the quad vector.

--- a/src/qvector/rs_qvector.rs
+++ b/src/qvector/rs_qvector.rs
@@ -604,7 +604,6 @@ where
 #[generic_tests::define]
 mod tests {
     use super::*;
-    use std::iter;
 
     #[test]
     fn test_just_one_data_line<D>()
@@ -691,7 +690,7 @@ mod tests {
         ] {
             // tests blocks and superblocks boundaries
             for symbol in 0..3u8 {
-                let qv: QVector = iter::repeat(symbol).take(n).collect();
+                let qv: QVector = std::iter::repeat_n(symbol, n).collect();
                 let rsqv = D::from(qv.clone());
                 for i in 0..qv.len() + 1 {
                     if i < qv.len() {

--- a/src/qvector/rs_qvector/rs_support_plain.rs
+++ b/src/qvector/rs_qvector/rs_support_plain.rs
@@ -216,7 +216,23 @@ impl<const B_SIZE: usize> RSSupportPlain<B_SIZE> {
     pub fn select_samples(&self, s: usize) -> &[u32] {
         &self.select_samples[s]
     }
+
+    /// Build from precomputed superblocks and select samples.
+    ///
+    /// Inverse of [`superblocks`](Self::superblocks) +
+    /// [`select_samples`](Self::select_samples). Used by zero-copy I/O.
+    #[must_use]
+    pub fn from_parts(
+        superblocks: Box<[SuperblockPlain]>,
+        select_samples: [Box<[u32]>; 4],
+    ) -> Self {
+        Self {
+            superblocks,
+            select_samples,
+        }
+    }
 }
+
 
 /// Stores counters for a superblock and its blocks.
 /// We use a u128 for each of the 4 symbols.
@@ -234,6 +250,16 @@ pub struct SuperblockPlain {
 impl SuperblockPlain {
     const BLOCKS_IN_SUPERBLOCK: usize = 8; // Number of blocks in each superblock
 
+    /// Build from the four packed counter words.
+    ///
+    /// This is the inverse of reading [`counters`](Self::counters) and is the
+    /// assembly path used by zero-copy I/O.
+    #[inline]
+    #[must_use]
+    pub fn from_counters(counters: [u128; 4]) -> Self {
+        Self { counters }
+    }
+
     /// Creates a new superblock initialized with the number of occurrences
     /// of the four symbols from the beginning of the text.
     fn new(sbc: &[usize; 4]) -> Self {
@@ -243,6 +269,7 @@ impl SuperblockPlain {
         }
 
         Self { counters }
+
     }
 
     #[inline(always)]

--- a/src/qvector/rs_qvector/rs_support_plain.rs
+++ b/src/qvector/rs_qvector/rs_support_plain.rs
@@ -290,11 +290,11 @@ impl SuperblockPlain {
         let not_first = (block_id > 0) as usize;
         let shift = (block_id - not_first) * 12;
         let mut out = [0usize; 4];
-        for symbol in 0..4 {
+        for (symbol, slot) in out.iter_mut().enumerate() {
             let data = unsafe { *self.counters.get_unchecked(symbol) };
             let sb = (data >> 84) as usize;
             let b = ((data >> shift) as usize & 0b111111111111) * not_first;
-            out[symbol] = sb + b;
+            *slot = sb + b;
         }
         out
     }

--- a/src/qvector/rs_qvector/rs_support_plain.rs
+++ b/src/qvector/rs_qvector/rs_support_plain.rs
@@ -6,9 +6,7 @@ use crate::qvector::rs_qvector::RSSupport;
 use crate::utils::prefetch_read_NTA;
 use crate::AccessQuad;
 use crate::QVector; // Traits
-
-use mem_dbg::MemDbg;
-use mem_dbg::MemSize;
+use mem_dbg::{MemDbg, MemSize};
 use serde::{Deserialize, Serialize};
 
 /// The generic const `B_SIZE` specifies the number of symbols in each block.
@@ -119,7 +117,7 @@ impl<const B_SIZE: usize> RSSupport for RSSupportPlain<B_SIZE> {
                 .map(|sample| sample.into_boxed_slice())
                 .collect::<Vec<_>>()
                 .try_into()
-                .unwrap(), // all this just to convert Vecs into boxed slices (and because we cannot collect into an array directly)
+                .unwrap(), /* all this just to convert Vecs into boxed slices (and because we cannot collect into an array directly) */
         }
     }
 
@@ -205,6 +203,19 @@ impl<const B_SIZE: usize> RSSupportPlain<B_SIZE> {
     fn block_index(i: usize) -> usize {
         i / Self::BLOCK_SIZE
     }
+
+    /// Superblock counter lines. Exposed for zero-copy / mmap flatten.
+    #[inline]
+    pub fn superblocks(&self) -> &[SuperblockPlain] {
+        &self.superblocks
+    }
+
+    /// Select samples for symbol `s ∈ 0..4`.
+    /// Exposed for zero-copy / mmap flatten.
+    #[inline]
+    pub fn select_samples(&self, s: usize) -> &[u32] {
+        &self.select_samples[s]
+    }
 }
 
 /// Stores counters for a superblock and its blocks.
@@ -212,10 +223,12 @@ impl<const B_SIZE: usize> RSSupportPlain<B_SIZE> {
 /// A u128 is subdivided as follows:
 /// - First 44 bits to store superblock counters
 /// - Next 84 to store counters for 7 (out of 8) blocks (the first one is excluded)
+///
+/// Public for zero-copy / mmap flatten (byte-identical on-disk layout).
 #[derive(Debug, Default, Copy, Clone, Serialize, Deserialize, MemSize, MemDbg, PartialEq)]
 #[repr(C, align(64))]
-struct SuperblockPlain {
-    counters: [u128; 4],
+pub struct SuperblockPlain {
+    pub counters: [u128; 4],
 }
 
 impl SuperblockPlain {
@@ -233,7 +246,7 @@ impl SuperblockPlain {
     }
 
     #[inline(always)]
-    fn get_rank(&self, symbol: u8, block_id: usize) -> usize {
+    pub fn get_rank(&self, symbol: u8, block_id: usize) -> usize {
         let data = unsafe { *self.counters.get_unchecked(symbol as usize) };
         let sb = (data >> 84) as usize;
 
@@ -244,14 +257,34 @@ impl SuperblockPlain {
         sb + b
     }
 
-    fn get_superblock_counter(&self, symbol: u8) -> usize {
+    /// Block ranks for all four symbols at the same `block_id` (shared superblock load pattern).
+    ///
+    /// Fused 4-symbol block ranks (loads one superblock once).
+    #[inline(always)]
+    pub fn get_rank_all(&self, block_id: usize) -> [usize; 4] {
+        let not_first = (block_id > 0) as usize;
+        let shift = (block_id - not_first) * 12;
+        let mut out = [0usize; 4];
+        for symbol in 0..4 {
+            let data = unsafe { *self.counters.get_unchecked(symbol) };
+            let sb = (data >> 84) as usize;
+            let b = ((data >> shift) as usize & 0b111111111111) * not_first;
+            out[symbol] = sb + b;
+        }
+        out
+    }
+
+    /// Superblock-prefix counter for `symbol`.
+    /// Exposed for zero-copy / mmap flatten.
+    #[inline(always)]
+    pub fn get_superblock_counter(&self, symbol: u8) -> usize {
         (unsafe { *self.counters.get_unchecked(symbol as usize) } >> 84) as usize
     }
 
     fn set_block_counters(&mut self, block_id: usize, counters: &[usize; 4]) {
         assert!(block_id < 8);
         for &counter in counters.iter() {
-            //assert!(counters[i] < SUPERBLOCK_SIZE);
+            // assert!(counters[i] < SUPERBLOCK_SIZE);
             assert!(counter < (1 << 12));
         }
         if block_id == 0 {

--- a/src/qvector/rs_qvector/rs_support_plain.rs
+++ b/src/qvector/rs_qvector/rs_support_plain.rs
@@ -233,7 +233,6 @@ impl<const B_SIZE: usize> RSSupportPlain<B_SIZE> {
     }
 }
 
-
 /// Stores counters for a superblock and its blocks.
 /// We use a u128 for each of the 4 symbols.
 /// A u128 is subdivided as follows:
@@ -246,8 +245,6 @@ impl<const B_SIZE: usize> RSSupportPlain<B_SIZE> {
 pub struct SuperblockPlain {
     pub(crate) counters: [u128; 4],
 }
-
-
 
 impl SuperblockPlain {
     const BLOCKS_IN_SUPERBLOCK: usize = 8; // Number of blocks in each superblock
@@ -271,7 +268,6 @@ impl SuperblockPlain {
         }
 
         Self { counters }
-
     }
 
     #[inline(always)]

--- a/src/qvector/rs_qvector/rs_support_plain.rs
+++ b/src/qvector/rs_qvector/rs_support_plain.rs
@@ -206,14 +206,14 @@ impl<const B_SIZE: usize> RSSupportPlain<B_SIZE> {
 
     /// Superblock counter lines. Exposed for zero-copy / mmap flatten.
     #[inline]
-    pub fn superblocks(&self) -> &[SuperblockPlain] {
+    pub(crate) fn superblocks(&self) -> &[SuperblockPlain] {
         &self.superblocks
     }
 
     /// Select samples for symbol `s ∈ 0..4`.
     /// Exposed for zero-copy / mmap flatten.
     #[inline]
-    pub fn select_samples(&self, s: usize) -> &[u32] {
+    pub(crate) fn select_samples(&self, s: usize) -> &[u32] {
         &self.select_samples[s]
     }
 
@@ -240,12 +240,14 @@ impl<const B_SIZE: usize> RSSupportPlain<B_SIZE> {
 /// - First 44 bits to store superblock counters
 /// - Next 84 to store counters for 7 (out of 8) blocks (the first one is excluded)
 ///
-/// Public for zero-copy / mmap flatten (byte-identical on-disk layout).
+/// POD layout for zero-copy I/O; fields are crate-private (Group B).
 #[derive(Debug, Default, Copy, Clone, Serialize, Deserialize, MemSize, MemDbg, PartialEq)]
 #[repr(C, align(64))]
 pub struct SuperblockPlain {
-    pub counters: [u128; 4],
+    pub(crate) counters: [u128; 4],
 }
+
+
 
 impl SuperblockPlain {
     const BLOCKS_IN_SUPERBLOCK: usize = 8; // Number of blocks in each superblock

--- a/src/qvector/rs_qvector/rs_support_plain.rs
+++ b/src/qvector/rs_qvector/rs_support_plain.rs
@@ -321,7 +321,7 @@ impl SuperblockPlain {
         }
     }
 
-    fn get_block_counter(&self, symbol: u8, block_id: usize) -> usize {
+    pub(crate) fn get_block_counter(&self, symbol: u8, block_id: usize) -> usize {
         debug_assert!(block_id < Self::BLOCKS_IN_SUPERBLOCK);
 
         if block_id == 0 {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -131,7 +131,6 @@ const K_SELECT_IN_BYTE: [u8; 2048] = [
 /// - \[2\] Simon Gog, Matthias Petri. Optimized succinct data structures for massive data. Softw. Pract. Exper., 2014
 /// - \[3\] Sebastiano Vigna. MG4J 5.2.1. <http://mg4j.di.unimi.it/>
 /// - \[4\] Facebook Folly library: <https://github.com/facebook/folly>
-
 #[inline(always)]
 pub fn select_in_word(word: u64, k: u64) -> u32 {
     // use core::arch::x86_64::_pdep_u64;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,7 +12,6 @@ pub fn prefetch_read_NTA<T>(data: &[T], offset: usize) {
     {
         #[cfg(target_arch = "x86")]
         use std::arch::x86::{_mm_prefetch, _MM_HINT_NTA};
-
         #[cfg(target_arch = "x86_64")]
         use std::arch::x86_64::{_mm_prefetch, _MM_HINT_NTA};
 
@@ -185,9 +184,8 @@ pub fn popcnt_wide<const N: usize>(data: &[u64]) -> usize {
     res
 }
 
-use std::mem;
-
 use crate::quadwt::huffqwt::PrefixCode;
+use std::mem;
 
 #[repr(C, align(64))]
 struct AlignToSixtyFour([u8; 64]);
@@ -286,10 +284,10 @@ where
     for &a in sequence.iter() {
         let code = &codes[a.as_()];
         if code.len <= shift as u32 {
-            //we dont care about this symbol (already taken care of)
+            // we dont care about this symbol (already taken care of)
             vecs[4].push(a);
         } else {
-            //we partition as normal
+            // we partition as normal
             let two_bits = (code.content >> (code.len - shift as u32)) & 3;
             vecs[two_bits as usize].push(a);
         }
@@ -312,7 +310,7 @@ where
     for &a in sequence.iter() {
         let code = &codes[a.as_()];
         if code.len <= shift as u32 {
-            //we dont care about this symbol (already taken care of)
+            // we dont care about this symbol (already taken care of)
             vecs[2].push(a);
         } else {
             let bit = (code.content >> (code.len - shift as u32)) & 1;


### PR DESCRIPTION
## Summary

This follow-up hardens the byte I/O and Huffman paths introduced by #32.

- validate QWTB/HQWB type widths, level counts, checked directory arithmetic, payload lengths, and symbol bounds
- rebuild owned rank/select metadata from the encoded symbols instead of trusting persisted counters
- fully validate borrowed-view rank/select counters and child offsets before queries can reach unchecked paths
- validate Huffman code lengths/content, sorted encode/decode mappings, rank paths, and every populated prefix path
- reject terminal Huffman prefixes that still have populated descendants
- cap valid overwide Huffman code lengths to the u32 representation while preserving short codes for frequent symbols
- route Serde decoding through validated `from_parts` constructors and reject persisted prefetch metadata
- make raw POD cast/copy/write helpers explicitly unsafe and document their caller invariants

## Dependency

This PR is stacked on #32 and should be reviewed/merged after it. Until #32 lands, GitHub shows the byte-I/O commits in this PR's diff as well; after #32 merges I will rebase this branch so only the hardening commit remains.

This complements #40, which covers the independent core succinct-structure and deserialization invariants.

## Security impact

Malformed QWTB/HQWB or Serde input could otherwise supply inconsistent derived metadata, overflow layout arithmetic, or steer safe public queries into unchecked indexing. The decoder now rejects those states before constructing a usable tree.

## Verification

- `cargo test --all-features` — 255 tests passed
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`