### PR TITLE
Dispatch POPCNT safely at runtime

### DIFF
--- a/src/darray/mod.rs
+++ b/src/darray/mod.rs
@@ -61,14 +61,18 @@
 //! `select0` as well.
 
 use crate::bitvector::{BitVectorBitPositionsIter, BitVectorIter};
+#[cfg(not(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "popcnt"
+)))]
+use crate::kernel::scalar_popcount_u64;
+use crate::kernel::{selected_popcount_path, PopcountPath};
 use crate::utils::select_in_word;
 use crate::BitVector;
 use crate::{AccessBin, SelectBin};
 
 use mem_dbg::{MemDbg, MemSize};
 use serde::{Deserialize, Serialize};
-#[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::_popcnt64;
 
 const BLOCK_SIZE: usize = 1024;
 const SUBBLOCK_SIZE: usize = 32;
@@ -382,32 +386,52 @@ impl<const SELECT0_SUPPORT: bool> DArray<SELECT0_SUPPORT> {
         }
         let subblock = i / SUBBLOCK_SIZE;
         let start_pos = (block_pos as usize) + (inventories.subblock_inventory[subblock] as usize);
-        let mut reminder = i & (SUBBLOCK_SIZE - 1);
+        let reminder = i & (SUBBLOCK_SIZE - 1);
 
         if reminder == 0 {
             return Some(start_pos);
         }
 
-        let mut word_idx = start_pos >> 6;
+        let word_idx = start_pos >> 6;
         let word_shift = start_pos & 63;
-        let mut word = if !BIT {
-            !self.bv.get_word(word_idx) & (std::u64::MAX << word_shift) // if select0, negate the current word!
+        let word = if !BIT {
+            !self.bv.get_word(word_idx) & (u64::MAX << word_shift) // if select0, negate the current word!
         } else {
-            self.bv.get_word(word_idx) & (std::u64::MAX << word_shift)
+            self.bv.get_word(word_idx) & (u64::MAX << word_shift)
         };
 
+        let (word_idx, word, reminder) = match selected_popcount_path() {
+            #[cfg(not(all(
+                any(target_arch = "x86", target_arch = "x86_64"),
+                target_feature = "popcnt"
+            )))]
+            PopcountPath::Scalar => {
+                self.scan_select_words::<BIT, _>(reminder, word_idx, word, scalar_popcount_u64)
+            }
+            // SAFETY: `Popcnt` is selected only when the build or host supports it.
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            PopcountPath::Popcnt => unsafe {
+                self.scan_select_words_popcnt::<BIT>(reminder, word_idx, word)
+            },
+        };
+        let select_intra = select_in_word(word, reminder as u64) as usize;
+
+        Some((word_idx << 6) + select_intra)
+    }
+
+    #[inline(always)]
+    fn scan_select_words<const BIT: bool, F>(
+        &self,
+        mut reminder: usize,
+        mut word_idx: usize,
+        mut word: u64,
+        popcount: F,
+    ) -> (usize, u64, usize)
+    where
+        F: Fn(u64) -> usize,
+    {
         loop {
-            let popcnt;
-            #[cfg(not(target_arch = "x86_64"))]
-            {
-                popcnt = word.count_ones() as usize;
-            }
-            #[cfg(target_arch = "x86_64")]
-            {
-                unsafe {
-                    popcnt = _popcnt64(word as i64) as usize;
-                }
-            }
+            let popcnt = popcount(word);
             if reminder < popcnt {
                 break;
             }
@@ -418,9 +442,36 @@ impl<const SELECT0_SUPPORT: bool> DArray<SELECT0_SUPPORT> {
                 word = !word; // if select0, negate the current word!
             }
         }
-        let select_intra = select_in_word(word, reminder as u64) as usize;
+        (word_idx, word, reminder)
+    }
 
-        Some((word_idx << 6) + select_intra)
+    #[cfg(target_arch = "x86_64")]
+    #[inline]
+    #[target_feature(enable = "popcnt")]
+    unsafe fn scan_select_words_popcnt<const BIT: bool>(
+        &self,
+        reminder: usize,
+        word_idx: usize,
+        word: u64,
+    ) -> (usize, u64, usize) {
+        self.scan_select_words::<BIT, _>(reminder, word_idx, word, |value| {
+            std::arch::x86_64::_popcnt64(value as i64) as usize
+        })
+    }
+
+    #[cfg(target_arch = "x86")]
+    #[inline]
+    #[target_feature(enable = "popcnt")]
+    unsafe fn scan_select_words_popcnt<const BIT: bool>(
+        &self,
+        reminder: usize,
+        word_idx: usize,
+        word: u64,
+    ) -> (usize, u64, usize) {
+        self.scan_select_words::<BIT, _>(reminder, word_idx, word, |value| {
+            (std::arch::x86::_popcnt32(value as i32)
+                + std::arch::x86::_popcnt32((value >> 32) as i32)) as usize
+        })
     }
 }
 

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,0 +1,121 @@
+//! Host-safe selection for architecture-specific QWT primitives.
+//!
+//! Selection is internal and automatic: supported hosts use POPCNT, while
+//! every other target uses the portable scalar implementation.
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    not(target_feature = "popcnt")
+))]
+use std::sync::OnceLock;
+
+/// Selected implementation for the bounded popcount primitive.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PopcountPath {
+    #[cfg(not(all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature = "popcnt"
+    )))]
+    Scalar,
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    Popcnt,
+}
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    not(target_feature = "popcnt")
+))]
+static POPCOUNT_PATH: OnceLock<PopcountPath> = OnceLock::new();
+
+/// Select the host-safe implementation once for the process.
+#[inline(always)]
+pub(crate) fn selected_popcount_path() -> PopcountPath {
+    #[cfg(all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature = "popcnt"
+    ))]
+    {
+        PopcountPath::Popcnt
+    }
+    #[cfg(all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        not(target_feature = "popcnt")
+    ))]
+    {
+        *POPCOUNT_PATH.get_or_init(detect_popcount_path)
+    }
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    {
+        PopcountPath::Scalar
+    }
+}
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    not(target_feature = "popcnt")
+))]
+fn detect_popcount_path() -> PopcountPath {
+    if std::arch::is_x86_feature_detected!("popcnt") {
+        return PopcountPath::Popcnt;
+    }
+    PopcountPath::Scalar
+}
+
+/// Portable fallback; compiler lowering respects the build's target baseline.
+#[cfg(any(
+    test,
+    not(all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        target_feature = "popcnt"
+    ))
+))]
+#[inline(always)]
+pub(crate) fn scalar_popcount_u64(word: u64) -> usize {
+    word.count_ones() as usize
+}
+
+#[cfg(all(test, target_arch = "x86_64"))]
+#[target_feature(enable = "popcnt")]
+pub(crate) unsafe fn popcount_u64_popcnt(word: u64) -> usize {
+    std::arch::x86_64::_popcnt64(word as i64) as usize
+}
+
+#[cfg(all(test, target_arch = "x86"))]
+#[target_feature(enable = "popcnt")]
+pub(crate) unsafe fn popcount_u64_popcnt(word: u64) -> usize {
+    (std::arch::x86::_popcnt32(word as i32) + std::arch::x86::_popcnt32((word >> 32) as i32))
+        as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scalar_path_matches_rust_popcount() {
+        let mut value = 0x9e37_79b9_7f4a_7c15u64;
+        for _ in 0..10_000 {
+            value = value
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            assert_eq!(scalar_popcount_u64(value), value.count_ones() as usize);
+        }
+    }
+
+    #[test]
+    fn selected_path_is_host_safe_and_correct() {
+        for value in [0, 1, u64::MAX, 0xf0f0_aaaa_5555_1234] {
+            let count = match selected_popcount_path() {
+                #[cfg(not(all(
+                    any(target_arch = "x86", target_arch = "x86_64"),
+                    target_feature = "popcnt"
+                )))]
+                PopcountPath::Scalar => scalar_popcount_u64(value),
+                // SAFETY: `Popcnt` is selected only when the build or host supports it.
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                PopcountPath::Popcnt => unsafe { popcount_u64_popcnt(value) },
+            };
+            assert_eq!(count, value.count_ones() as usize);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub use bitvector::narrow::RS as RSNarrow;
 #[deprecated(since = "0.5.0", note = "renamed to `qwt::wide::RS`")]
 pub use bitvector::wide::RS as RSWide;
 
+mod kernel;
 pub mod utils;
 
 pub use qvector::rs_qvector::RSQVector;


### PR DESCRIPTION
## Summary

- replace the unconditional x86_64 POPCNT intrinsic with host-safe selection
- keep a compile-time POPCNT fast path when the target already guarantees the instruction
- detect POPCNT once on generic x86 and x86_64 builds, with a portable count_ones fallback
- keep selection internal and outside the scanned-word loop

This prevents illegal-instruction failures on generic x86 hosts without adding an operator-facing ISA policy.

## Validation

- cargo test --all-features: 198 passed
- generic x86_64-unknown-linux-gnu cargo check passed
- x86_64-unknown-linux-gnu check with target-feature=+popcnt passed
- changed code passes Clippy with warnings denied; upstream main has unrelated pre-existing Clippy findings